### PR TITLE
Auxiliary changes for AleRax reconciliation model refactoring

### DIFF
--- a/src/IO/ReconciliationWriter.cpp
+++ b/src/IO/ReconciliationWriter.cpp
@@ -93,7 +93,7 @@ static void printEventALE(const Scenario::Event &event,
   switch (event.type) {
   case ReconciliationEventType::EVENT_S:
   case ReconciliationEventType::EVENT_SL:
-    os << "S@" << species->label;
+    os << species->label;
     break;
   case ReconciliationEventType::EVENT_D:
     os << "D@" << species->label;
@@ -103,9 +103,6 @@ static void printEventALE(const Scenario::Event &event,
     speciesDest = speciesTree->nodes[event.destSpeciesNode];
     assert(speciesDest->label);
     os << "T@" << species->label << "->" << speciesDest->label;
-    break;
-  case ReconciliationEventType::EVENT_None:
-    os << "Leaf@" << species->label << "...";
     break;
   default:
     break;
@@ -127,11 +124,12 @@ static void recursivelySaveReconciliationsALE(
                                       geneToEvents, os);
     os << ")";
   }
-  for (const auto &event : geneToEvents[node->node_index]) {
-    printEventALE(event, speciesTree, os);
-  }
   if (!node->next) {
     os << (node->label ? node->label : "null");
+  } else {
+    for (const auto &event : geneToEvents[node->node_index]) {
+      printEventALE(event, speciesTree, os);
+    }
   }
   // divide the root BL by two to place the root
   // at the middle of this branch

--- a/src/IO/ReconciliationWriter.cpp
+++ b/src/IO/ReconciliationWriter.cpp
@@ -1,47 +1,45 @@
 #include "ReconciliationWriter.hpp"
 
 #include <IO/ParallelOfstream.hpp>
-#include <corax/corax.h>
-#include <trees/PLLRootedTree.hpp>
 
+/**
+ *
+ *  NHX format
+ *
+ */
 static void printEventNHX(const Scenario::Event &event,
-                          corax_rtree_t *speciesTree, corax_unode_t *node,
+                          corax_rtree_t *speciesTree, double nodeBL,
                           ParallelOfstream &os) {
-  if (event.isValid()) {
-    os << "[&&NHX";
-    if (speciesTree->nodes[event.speciesNode]->label) {
-      os << ":S=" << speciesTree->nodes[event.speciesNode]->label;
-    }
-    os << ":D="
-       << ((event.type == ReconciliationEventType::EVENT_D ||
-            event.type == ReconciliationEventType::EVENT_DL)
-               ? "Y"
-               : "N");
-    os << ":H="
-       << ((event.type == ReconciliationEventType::EVENT_T ||
-            event.type == ReconciliationEventType::EVENT_TL)
-               ? "Y"
-               : "N");
-    if (event.type == ReconciliationEventType::EVENT_T ||
-        event.type == ReconciliationEventType::EVENT_TL) {
-      assert(speciesTree->nodes[event.speciesNode]->label);
-      assert(speciesTree->nodes[event.destSpeciesNode]->label);
-      os << "@" << speciesTree->nodes[event.speciesNode]->label;
-      os << "@" << speciesTree->nodes[event.destSpeciesNode]->label;
-    }
-    os << ":B=" << node->length;
-    os << "]";
+  assert(event.isValid());
+  corax_rnode_t *species = speciesTree->nodes[event.speciesNode];
+  corax_rnode_t *speciesDest = nullptr;
+  assert(species->label);
+  os << "[&&NHX";
+  os << ":S=" << species->label;
+  os << ":D=" << ((event.type == ReconciliationEventType::EVENT_D) ? "Y" : "N");
+  os << ":H="
+     << ((event.type == ReconciliationEventType::EVENT_T ||
+          event.type == ReconciliationEventType::EVENT_TL)
+             ? "Y"
+             : "N");
+  if (event.type == ReconciliationEventType::EVENT_T ||
+      event.type == ReconciliationEventType::EVENT_TL) {
+    speciesDest = speciesTree->nodes[event.destSpeciesNode];
+    assert(speciesDest->label);
+    os << "@" << species->label;
+    os << "@" << speciesDest->label;
   }
+  os << ":B=" << nodeBL;
+  os << "]";
 }
 
 static void recursivelySaveReconciliationsNHX(
-    corax_rtree_t *speciesTree, corax_unode_t *node, bool isVirtualRoot,
+    corax_rtree_t *speciesTree, corax_unode_t *node, unsigned int depth,
     std::vector<std::vector<Scenario::Event>> &geneToEvents,
     ParallelOfstream &os) {
   if (node->next) {
-    corax_unode_t *left = nullptr;
-    corax_unode_t *right = nullptr;
-    if (isVirtualRoot) {
+    corax_unode_t *left, *right;
+    if (depth == 0) {
       left = node->next;
       right = node->next->back;
     } else {
@@ -49,11 +47,11 @@ static void recursivelySaveReconciliationsNHX(
       right = node->next->next->back;
     }
     os << "(";
-    recursivelySaveReconciliationsNHX(speciesTree, left, false, geneToEvents,
-                                      os);
+    recursivelySaveReconciliationsNHX(speciesTree, left, depth + 1,
+                                      geneToEvents, os);
     os << ",";
-    recursivelySaveReconciliationsNHX(speciesTree, right, false, geneToEvents,
-                                      os);
+    recursivelySaveReconciliationsNHX(speciesTree, right, depth + 1,
+                                      geneToEvents, os);
     os << ")";
   }
   if (node->label) {
@@ -61,10 +59,13 @@ static void recursivelySaveReconciliationsNHX(
   } else {
     os << "n" << node->node_index;
   }
-  if (!isVirtualRoot) {
-    os << ":" << node->length;
+  // we split the length of the virtual root in two
+  // for each branch under the root
+  auto nodeBL = (depth == 1) ? (node->length / 2.0) : node->length;
+  if (depth > 0) {
+    os << ":" << nodeBL;
   }
-  printEventNHX(geneToEvents[node->node_index].back(), speciesTree, node, os);
+  printEventNHX(geneToEvents[node->node_index].back(), speciesTree, nodeBL, os);
 }
 
 void ReconciliationWriter::saveReconciliationNHX(
@@ -77,46 +78,53 @@ void ReconciliationWriter::saveReconciliationNHX(
   virtualRoot.node_index = virtualRootIndex;
   virtualRoot.label = nullptr;
   virtualRoot.length = 0.0;
-  recursivelySaveReconciliationsNHX(speciesTree, &virtualRoot, true,
-                                    geneToEvents, os);
+  recursivelySaveReconciliationsNHX(speciesTree, &virtualRoot, 0, geneToEvents,
+                                    os);
   os << ";";
   os << std::endl;
 }
 
+/**
+ *
+ *  AleRec format
+ *
+ */
 static void printEventALE(const Scenario::Event &event,
-                          corax_rtree_t *speciesTree, corax_unode_t *node,
-                          ParallelOfstream &os) {
-  auto label = speciesTree->nodes[event.speciesNode]->label;
-  if (event.isValid()) {
-    os << ".";
-    switch (event.type) {
-    case ReconciliationEventType::EVENT_S:
-    case ReconciliationEventType::EVENT_SL:
-      os << label;
-      break;
-    case ReconciliationEventType::EVENT_D:
-    case ReconciliationEventType::EVENT_DL:
-      os << "D@" << label;
-      break;
-    case ReconciliationEventType::EVENT_T:
-    case ReconciliationEventType::EVENT_TL:
-      os << "T@" << label << "->"
-         << speciesTree->nodes[event.destSpeciesNode]->label;
-      break;
-    default:
-      break;
-    };
+                          corax_rtree_t *speciesTree, ParallelOfstream &os) {
+  assert(event.isValid());
+  corax_rnode_t *species = speciesTree->nodes[event.speciesNode];
+  corax_rnode_t *speciesDest = nullptr;
+  assert(species->label);
+  os << ".";
+  switch (event.type) {
+  case ReconciliationEventType::EVENT_S:
+  case ReconciliationEventType::EVENT_SL:
+    os << "S@" << species->label;
+    break;
+  case ReconciliationEventType::EVENT_D:
+    os << "D@" << species->label;
+    break;
+  case ReconciliationEventType::EVENT_T:
+  case ReconciliationEventType::EVENT_TL:
+    speciesDest = speciesTree->nodes[event.destSpeciesNode];
+    assert(speciesDest->label);
+    os << "T@" << species->label << "->" << speciesDest->label;
+    break;
+  case ReconciliationEventType::EVENT_None:
+    os << "Leaf@" << species->label << "...";
+    break;
+  default:
+    break;
   }
 }
 
 static void recursivelySaveReconciliationsALE(
-    corax_rtree_t *speciesTree, corax_unode_t *node, bool isVirtualRoot,
+    corax_rtree_t *speciesTree, corax_unode_t *node, unsigned int depth,
     std::vector<std::vector<Scenario::Event>> &geneToEvents,
     ParallelOfstream &os) {
   if (node->next) {
-    corax_unode_t *left = nullptr;
-    corax_unode_t *right = nullptr;
-    if (isVirtualRoot) {
+    corax_unode_t *left, *right;
+    if (depth == 0) {
       left = node->next;
       right = node->next->back;
     } else {
@@ -124,22 +132,24 @@ static void recursivelySaveReconciliationsALE(
       right = node->next->next->back;
     }
     os << "(";
-    recursivelySaveReconciliationsALE(speciesTree, left, false, geneToEvents,
-                                      os);
+    recursivelySaveReconciliationsALE(speciesTree, left, depth + 1,
+                                      geneToEvents, os);
     os << ",";
-    recursivelySaveReconciliationsALE(speciesTree, right, false, geneToEvents,
-                                      os);
+    recursivelySaveReconciliationsALE(speciesTree, right, depth + 1,
+                                      geneToEvents, os);
     os << ")";
   }
-  if (!node->next) {
-    os << node->label;
-  } else {
-    for (auto &event : geneToEvents[node->node_index]) {
-      printEventALE(event, speciesTree, node, os);
-    }
+  for (auto &event : geneToEvents[node->node_index]) {
+    printEventALE(event, speciesTree, os);
   }
-  if (!isVirtualRoot) {
-    os << ":" << node->length;
+  if (!node->next) {
+    os << (node->label ? node->label : "null");
+  }
+  // we split the length of the virtual root in two
+  // for each branch under the root
+  auto nodeBL = (depth == 1) ? (node->length / 2.0) : node->length;
+  if (depth > 0) {
+    os << ":" << nodeBL;
   }
 }
 
@@ -153,27 +163,29 @@ void ReconciliationWriter::saveReconciliationALE(
   virtualRoot.node_index = virtualRootIndex;
   virtualRoot.label = nullptr;
   virtualRoot.length = 0.0;
-  recursivelySaveReconciliationsALE(speciesTree, &virtualRoot, true,
-                                    geneToEvents, os);
+  recursivelySaveReconciliationsALE(speciesTree, &virtualRoot, 0, geneToEvents,
+                                    os);
   os << ";";
   os << std::endl;
 }
 
-static void recursivelySaveSpeciesTreeRecPhyloXML(corax_rnode_t *node,
+/**
+ *
+ *  RecPhyloXML format
+ *
+ */
+static void recursivelySaveSpeciesTreeRecPhyloXML(corax_rnode_t *species,
                                                   std::string &indent,
                                                   ParallelOfstream &os) {
-  if (!node) {
+  if (!species) {
     return;
   }
   os << indent << "<clade>" << std::endl;
   indent += "\t";
-  std::string label(node->label);
-  if (!label.size()) {
-    label = "NULL";
-  }
-  os << indent << "\t<name>" << label << "</name>" << std::endl;
-  recursivelySaveSpeciesTreeRecPhyloXML(node->left, indent, os);
-  recursivelySaveSpeciesTreeRecPhyloXML(node->right, indent, os);
+  assert(species->label);
+  os << indent << "<name>" << species->label << "</name>" << std::endl;
+  recursivelySaveSpeciesTreeRecPhyloXML(species->left, indent, os);
+  recursivelySaveSpeciesTreeRecPhyloXML(species->right, indent, os);
   indent.pop_back();
   os << indent << "</clade>" << std::endl;
 }
@@ -188,27 +200,27 @@ static void saveSpeciesTreeRecPhyloXML(corax_rtree_t *speciesTree,
   os << "</spTree>" << std::endl;
 }
 
-static void writeEventRecPhyloXML(unsigned int geneIndex,
-                                  corax_rtree_t *speciesTree,
-                                  Scenario::Event &event,
+static void writeEventRecPhyloXML(corax_rtree_t *speciesTree,
+                                  unsigned int geneIndex,
+                                  const Scenario::Event &event,
                                   const Scenario::Event *previousEvent,
                                   std::string &indent, ParallelOfstream &os) {
-  auto species = speciesTree->nodes[event.speciesNode];
-  corax_rnode_t *speciesOut = 0;
+  corax_rnode_t *species = speciesTree->nodes[event.speciesNode];
+  assert(species->label);
   os << indent << "<eventsRec>" << std::endl;
   if (event.type != ReconciliationEventType::EVENT_L) {
     if ((previousEvent->type == ReconciliationEventType::EVENT_T &&
          geneIndex == previousEvent->rightGeneIndex) ||
         previousEvent->type == ReconciliationEventType::EVENT_TL) {
-      auto previousEventSpeciesOut =
+      corax_rnode_t *previousEventSpeciesDest =
           speciesTree->nodes[previousEvent->destSpeciesNode];
+      assert(previousEventSpeciesDest->label);
       os << indent << "\t<transferBack destinationSpecies=\""
-         << previousEventSpeciesOut->label << "\"/>" << std::endl;
+         << previousEventSpeciesDest->label << "\"/>" << std::endl;
     }
   }
   switch (event.type) {
   case ReconciliationEventType::EVENT_None:
-    assert(species->left == 0 && species->right == 0);
     os << indent << "\t<leaf speciesLocation=\"" << species->label << "\"/>"
        << std::endl;
     break;
@@ -218,19 +230,16 @@ static void writeEventRecPhyloXML(unsigned int geneIndex,
        << "\"/>" << std::endl;
     break;
   case ReconciliationEventType::EVENT_D:
-  case ReconciliationEventType::EVENT_DL:
     os << indent << "\t<duplication speciesLocation=\"" << species->label
        << "\"/>" << std::endl;
     break;
   case ReconciliationEventType::EVENT_T:
   case ReconciliationEventType::EVENT_TL:
-    speciesOut = speciesTree->nodes[event.speciesNode];
-    os << indent << "\t<branchingOut speciesLocation=\"" << speciesOut->label
+    os << indent << "\t<branchingOut speciesLocation=\"" << species->label
        << "\"/>" << std::endl;
     break;
   case ReconciliationEventType::EVENT_L:
-    speciesOut = speciesTree->nodes[event.speciesNode];
-    os << indent << "\t<loss speciesLocation=\"" << speciesOut->label << "\"/>"
+    os << indent << "\t<loss speciesLocation=\"" << species->label << "\"/>"
        << std::endl;
     break;
   default:
@@ -240,82 +249,78 @@ static void writeEventRecPhyloXML(unsigned int geneIndex,
 }
 
 static void recursivelySaveGeneTreeRecPhyloXML(
-    unsigned int geneIndex, corax_rtree_t *speciesTree,
+    corax_rtree_t *speciesTree, unsigned int geneIndex,
     std::vector<std::vector<Scenario::Event>> &geneToEvents,
     const Scenario::Event *previousEvent, std::string &indent,
     ParallelOfstream &os) {
   auto &events = geneToEvents[geneIndex];
+  // open new clades for loss events of the given geneIndex
   for (unsigned int i = 0; i < events.size() - 1; ++i) {
     os << indent << "<clade>" << std::endl;
     indent += "\t";
     auto &event = events[i];
+    assert(event.type == ReconciliationEventType::EVENT_SL ||
+           event.type == ReconciliationEventType::EVENT_TL);
     os << indent << "<name>" << "NULL" << "</name>" << std::endl;
-    writeEventRecPhyloXML(geneIndex, speciesTree, event, previousEvent, indent,
+    writeEventRecPhyloXML(speciesTree, geneIndex, event, previousEvent, indent,
                           os);
     previousEvent = &event;
-    if (event.type == ReconciliationEventType::EVENT_SL ||
-        event.type == ReconciliationEventType::EVENT_TL) {
-      Scenario::Event loss;
-      loss.type = ReconciliationEventType::EVENT_L;
-      if (event.type == ReconciliationEventType::EVENT_SL) {
-        auto parentSpecies = speciesTree->nodes[event.speciesNode];
-        auto lostSpecies =
-            (parentSpecies->left->node_index == event.destSpeciesNode)
-                ? parentSpecies->right
-                : parentSpecies->left;
-        loss.speciesNode = lostSpecies->node_index;
-      } else if (event.type == ReconciliationEventType::EVENT_TL) {
-        loss.speciesNode = event.speciesNode;
-      }
-      indent += "\t";
-      os << indent << "<clade>" << std::endl;
-      os << indent << "<name>loss</name>" << std::endl;
-      writeEventRecPhyloXML(geneIndex, speciesTree, loss, previousEvent, indent,
-                            os);
-      indent.pop_back();
-      os << indent << "</clade>" << std::endl;
-    } else {
-      assert(event.type == ReconciliationEventType::EVENT_DL);
-    }
+    // now we are one level further from the root:
+    // the two child clades are lossEvent and the next event from events
+    os << indent << "<clade>" << std::endl;
+    indent += "\t";
+    Scenario::Event lossEvent;
+    lossEvent.type = ReconciliationEventType::EVENT_L;
+    lossEvent.speciesNode = (event.type == ReconciliationEventType::EVENT_SL)
+                                ? event.lostSpeciesNode
+                                : event.speciesNode;
+    os << indent << "<name>loss</name>" << std::endl;
+    writeEventRecPhyloXML(speciesTree, geneIndex, lossEvent, previousEvent,
+                          indent, os);
+    indent.pop_back();
+    os << indent << "</clade>" << std::endl;
   }
+  // handle the last event of the given geneIndex
   os << indent << "<clade>" << std::endl;
   indent += "\t";
-  Scenario::Event &event = geneToEvents[geneIndex].back();
+  auto &event = events.back();
   auto label = event.label.size() ? event.label : "NULL";
   os << indent << "<name>" << label << "</name>" << std::endl;
-  writeEventRecPhyloXML(geneIndex, speciesTree, event, previousEvent, indent,
+  writeEventRecPhyloXML(speciesTree, geneIndex, event, previousEvent, indent,
                         os);
   if (!event.isLeaf()) {
-    recursivelySaveGeneTreeRecPhyloXML(event.leftGeneIndex, speciesTree,
+    recursivelySaveGeneTreeRecPhyloXML(speciesTree, event.leftGeneIndex,
                                        geneToEvents, &event, indent, os);
-    recursivelySaveGeneTreeRecPhyloXML(event.rightGeneIndex, speciesTree,
+    recursivelySaveGeneTreeRecPhyloXML(speciesTree, event.rightGeneIndex,
                                        geneToEvents, &event, indent, os);
   }
+  indent.pop_back();
+  os << indent << "</clade>" << std::endl;
+  // close the clades for loss events
   for (unsigned int i = 0; i < events.size() - 1; ++i) {
     indent.pop_back();
     os << indent << "</clade>" << std::endl;
   }
-  indent.pop_back();
-  os << indent << "</clade>" << std::endl;
 }
 
 static void
-saveGeneTreeRecPhyloXML(unsigned int geneIndex, corax_rtree_t *speciesTree,
+saveGeneTreeRecPhyloXML(corax_rtree_t *speciesTree,
+                        unsigned int virtualRootIndex,
                         std::vector<std::vector<Scenario::Event>> &geneToEvents,
                         ParallelOfstream &os) {
   os << "<recGeneTree>" << std::endl;
   os << "<phylogeny rooted=\"true\">" << std::endl;
   std::string indent;
   Scenario::Event previousEvent;
-  previousEvent.type = ReconciliationEventType::EVENT_None;
-  recursivelySaveGeneTreeRecPhyloXML(geneIndex, speciesTree, geneToEvents,
-                                     &previousEvent, indent, os);
+  previousEvent.type = ReconciliationEventType::EVENT_Invalid;
+  recursivelySaveGeneTreeRecPhyloXML(speciesTree, virtualRootIndex,
+                                     geneToEvents, &previousEvent, indent, os);
   os << "</phylogeny>" << std::endl;
   os << "</recGeneTree>" << std::endl;
 }
 
 void ReconciliationWriter::saveReconciliationRecPhyloXML(
-    corax_rtree_t *speciesTree, unsigned int geneIndex,
+    corax_rtree_t *speciesTree, unsigned int virtualRootIndex,
     std::vector<std::vector<Scenario::Event>> &geneToEvents,
     ParallelOfstream &os) {
   os << "<recPhylo " << std::endl;
@@ -325,10 +330,15 @@ void ReconciliationWriter::saveReconciliationRecPhyloXML(
      << std::endl;
   os << "\txmlns=\"http://www.recg.org\">" << std::endl;
   saveSpeciesTreeRecPhyloXML(speciesTree, os);
-  saveGeneTreeRecPhyloXML(geneIndex, speciesTree, geneToEvents, os);
+  saveGeneTreeRecPhyloXML(speciesTree, virtualRootIndex, geneToEvents, os);
   os << "</recPhylo>" << std::endl;
 }
 
+/**
+ *
+ *  NewickEvents format
+ *
+ */
 static void recursivelySaveReconciliationsNewickEvents(
     corax_unode_t *node, unsigned int depth,
     std::vector<std::vector<Scenario::Event>> &geneToEvents,
@@ -355,13 +365,11 @@ static void recursivelySaveReconciliationsNewickEvents(
   } else {
     os << Enums::getEventName(geneToEvents[node->node_index].back().type);
   }
-  if (depth == 1) {
-    // we split the length of the virtual root in two
-    // for each branch under the root
-    os << ":" << node->length / 2.0;
-  }
-  if (depth > 1) {
-    os << ":" << node->length;
+  // we split the length of the virtual root in two
+  // for each branch under the root
+  auto nodeBL = (depth == 1) ? (node->length / 2.0) : node->length;
+  if (depth > 0) {
+    os << ":" << nodeBL;
   }
 }
 

--- a/src/IO/ReconciliationWriter.hpp
+++ b/src/IO/ReconciliationWriter.hpp
@@ -1,10 +1,6 @@
 #pragma once
 
-#include <string>
-#include <vector>
-
 #include <util/Scenario.hpp>
-#include <util/enums.hpp>
 
 class ParallelOfstream;
 
@@ -15,27 +11,27 @@ public:
   /**
    *  Write a reconciliation into a stream using the NHX format
    */
-  static void
-  saveReconciliationNHX(corax_rtree_t *speciesTree, corax_unode_t *geneRoot,
-                        unsigned int virtualRootIndex,
-                        std::vector<std::vector<Scenario::Event>> &geneToEvent,
-                        ParallelOfstream &os);
+  static void saveReconciliationNHX(
+      corax_rtree_t *speciesTree, corax_unode_t *geneRoot,
+      unsigned int virtualRootIndex,
+      const std::vector<std::vector<Scenario::Event>> &geneToEvents,
+      ParallelOfstream &os);
 
   /**
    *  Write a reconciliation into a stream using the AleRec format
    */
-  static void
-  saveReconciliationALE(corax_rtree_t *speciesTree, corax_unode_t *geneRoot,
-                        unsigned int virtualRootIndex,
-                        std::vector<std::vector<Scenario::Event>> &geneToEvents,
-                        ParallelOfstream &os);
+  static void saveReconciliationALE(
+      corax_rtree_t *speciesTree, corax_unode_t *geneRoot,
+      unsigned int virtualRootIndex,
+      const std::vector<std::vector<Scenario::Event>> &geneToEvents,
+      ParallelOfstream &os);
 
   /**
    *  Write a reconciliation into a stream using the RecPhyloXML format
    */
   static void saveReconciliationRecPhyloXML(
       corax_rtree_t *speciesTree, unsigned int virtualRootIndex,
-      std::vector<std::vector<Scenario::Event>> &geneToEvent,
+      const std::vector<std::vector<Scenario::Event>> &geneToEvents,
       ParallelOfstream &os);
 
   /**
@@ -43,6 +39,6 @@ public:
    */
   static void saveReconciliationNewickEvents(
       corax_unode_t *geneRoot, unsigned int virtualRootIndex,
-      std::vector<std::vector<Scenario::Event>> &geneToEvent,
+      const std::vector<std::vector<Scenario::Event>> &geneToEvents,
       ParallelOfstream &os);
 };

--- a/src/IO/ReconciliationWriter.hpp
+++ b/src/IO/ReconciliationWriter.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
 #include <string>
+#include <vector>
+
 #include <util/Scenario.hpp>
 #include <util/enums.hpp>
-#include <vector>
-typedef struct corax_unode_s corax_unode_t;
-typedef struct corax_rtree_s corax_rtree_t;
+
 class ParallelOfstream;
 
 class ReconciliationWriter {
@@ -22,7 +22,7 @@ public:
                         ParallelOfstream &os);
 
   /**
-   *  Write a reconciliation into a stream using the ALE (.uml_rec files) format
+   *  Write a reconciliation into a stream using the AleRec format
    */
   static void
   saveReconciliationALE(corax_rtree_t *speciesTree, corax_unode_t *geneRoot,
@@ -34,12 +34,12 @@ public:
    *  Write a reconciliation into a stream using the RecPhyloXML format
    */
   static void saveReconciliationRecPhyloXML(
-      corax_rtree_t *speciesTree, unsigned int geneNode,
+      corax_rtree_t *speciesTree, unsigned int virtualRootIndex,
       std::vector<std::vector<Scenario::Event>> &geneToEvent,
       ParallelOfstream &os);
 
   /**
-   *  Write a reconciliation into a stream using the newick format
+   *  Write a reconciliation into a stream using the NewickEvents format
    */
   static void saveReconciliationNewickEvents(
       corax_unode_t *geneRoot, unsigned int virtualRootIndex,

--- a/src/ccp/ConditionalClades.cpp
+++ b/src/ccp/ConditionalClades.cpp
@@ -1,10 +1,11 @@
-
 #include "ConditionalClades.hpp"
-#include <IO/Logger.hpp>
+
 #include <cassert>
 #include <fstream>
 #include <iostream>
 #include <sstream>
+
+#include <IO/Logger.hpp>
 #include <trees/PLLRootedTree.hpp>
 #include <trees/PLLUnrootedTree.hpp>
 
@@ -193,9 +194,9 @@ extractClades(const WeightedTrees &weightedTrees,
   // clade always comes after its child clades in the CID ordering
   for (auto it = orderedClades.begin(); it != orderedClades.end(); ++it) {
     auto &clade = *it;
-    unsigned int CID = cidToClade.size();
+    unsigned int cid = cidToClade.size();
     cidToClade.push_back(clade);
-    cladeToCID[clade] = CID;
+    cladeToCID[clade] = cid;
   }
   // so far we have only added the non-trivial clades. Now we add
   // the trivial clades
@@ -525,7 +526,7 @@ void ConditionalClades::_fillCCP(
   _allCladeSplits.resize(cladesNumber);
   auto rootCID = cladesNumber - 1;
   CCPClade fullClade(_CIDToClade[0].size(), true);
-  assert(rootCID = _cladeToCID[fullClade]);
+  assert(rootCID == _cladeToCID[fullClade]);
   for (unsigned int cid = 0; cid < cladesNumber; ++cid) {
     auto &clade = _CIDToClade[cid];
     auto &cladeSplits = _allCladeSplits[cid];

--- a/src/ccp/ConditionalClades.cpp
+++ b/src/ccp/ConditionalClades.cpp
@@ -20,7 +20,7 @@ struct TreeWraper {
     tree = std::make_shared<PLLUnrootedTree>(newickStr, false);
     if (rooted) {
       rtree = std::make_shared<PLLRootedTree>(newickStr, false);
-      root = tree->getVirtualRoot(*rtree);
+      root = tree->getRoot(*rtree, true);
       hash = tree->getRootedTreeHash(root);
     } else {
       hash = tree->getUnrootedTreeHash();
@@ -161,12 +161,12 @@ extractClades(const WeightedTrees &weightedTrees,
   orderedClades.insert(fullClade);
   // iterate over all trees of the tree distribution
   for (auto pair : weightedTrees) {
-    auto virtualRoot = pair.first.root;
+    auto root = pair.first.root;
     auto &tree = *(pair.first.tree);
     std::vector<CCPClade> nodeIndexToClade(tree.getDirectedNodeNumber(),
                                            emptyClade);
-    if (virtualRoot) {
-      postOrderNodes.emplace_back(tree.getPostOrderNodesRooted(virtualRoot));
+    if (root) {
+      postOrderNodes.emplace_back(tree.getPostOrderNodesRooted(root));
     } else {
       postOrderNodes.emplace_back(tree.getPostOrderNodes());
     }

--- a/src/ccp/ConditionalClades.cpp
+++ b/src/ccp/ConditionalClades.cpp
@@ -11,15 +11,16 @@
 
 struct TreeWraper {
   std::shared_ptr<PLLUnrootedTree> tree;
+  std::shared_ptr<PLLRootedTree> rtree;
   corax_unode_t *root;
   size_t hash;
   double ll;
   TreeWraper(const std::string newickStr, bool rooted)
-      : root(nullptr), ll(0.0) {
+      : rtree(nullptr), root(nullptr), ll(0.0) {
     tree = std::make_shared<PLLUnrootedTree>(newickStr, false);
     if (rooted) {
-      PLLRootedTree rootedTree(newickStr, false);
-      root = tree->getVirtualRoot(rootedTree);
+      rtree = std::make_shared<PLLRootedTree>(newickStr, false);
+      root = tree->getVirtualRoot(*rtree);
       hash = tree->getRootedTreeHash(root);
     } else {
       hash = tree->getUnrootedTreeHash();
@@ -27,8 +28,7 @@ struct TreeWraper {
   }
 
   bool operator==(const TreeWraper &other) const {
-    return root == other.root &&
-           PLLUnrootedTree::areIsomorphic(*tree, *(other.tree));
+    return (root && other.root) ? *rtree == *other.rtree : *tree == *other.tree;
   }
 };
 

--- a/src/likelihoods/ReconciliationEvaluation.cpp
+++ b/src/likelihoods/ReconciliationEvaluation.cpp
@@ -100,8 +100,9 @@ ReconciliationEvaluation::buildRecModelObject(RecModel recModel,
   }
   corax_unode_t *forcedGeneRoot = nullptr;
   if (_forcedRootedGeneTree.size() > 0) {
-    auto rooted = PLLRootedTree::buildFromStrOrFile(_forcedRootedGeneTree);
-    forcedGeneRoot = _initialGeneTree.getVirtualRoot(*rooted);
+    auto rootedGeneTree =
+        PLLRootedTree::buildFromStrOrFile(_forcedRootedGeneTree);
+    forcedGeneRoot = _initialGeneTree.getRoot(*rootedGeneTree);
   }
   res->setInitialGeneTree(_initialGeneTree, forcedGeneRoot);
   return res;

--- a/src/likelihoods/ReconciliationEvaluation.cpp
+++ b/src/likelihoods/ReconciliationEvaluation.cpp
@@ -1,15 +1,9 @@
-
 #include "ReconciliationEvaluation.hpp"
-#include <IO/FileSystem.hpp>
-#include <IO/Logger.hpp>
-#include <cmath>
-#include <likelihoods/reconciliation_models/BaseReconciliationModel.hpp>
+
 #include <likelihoods/reconciliation_models/ParsimonyDModel.hpp>
 #include <likelihoods/reconciliation_models/SimpleDSModel.hpp>
 #include <likelihoods/reconciliation_models/UndatedDLModel.hpp>
 #include <likelihoods/reconciliation_models/UndatedDTLModel.hpp>
-
-double log(ScaledValue v) { return v.getLogValue(); }
 
 ReconciliationEvaluation::ReconciliationEvaluation(
     PLLRootedTree &speciesTree, PLLUnrootedTree &initialGeneTree,

--- a/src/likelihoods/reconciliation_models/BaseReconciliationModel.cpp
+++ b/src/likelihoods/reconciliation_models/BaseReconciliationModel.cpp
@@ -1,65 +1,15 @@
 #include "BaseReconciliationModel.hpp"
-#include <functional>
 
-static bool fillNodesPostOrder(corax_rnode_t *node,
-                               std::vector<corax_rnode_t *> &nodes) {
-  if (node->left) {
-    assert(node->right);
-    fillNodesPostOrder(node->left, nodes);
-    fillNodesPostOrder(node->right, nodes);
-  }
-  nodes.push_back(node);
-  return true;
-}
+#include <functional>
 
 BaseReconciliationModel::BaseReconciliationModel(
     PLLRootedTree &speciesTree, const GeneSpeciesMapping &geneSpeciesMapping,
     const RecModelInfo &recModelInfo)
     : _info(recModelInfo), _speciesTree(speciesTree),
-      _likelihoodMode(PartialLikelihoodMode::PartialGenes),
       _geneNameToSpeciesName(geneSpeciesMapping.getMap()),
       _allSpeciesNodesInvalid(true) {
   initSpeciesTree();
   setFractionMissingGenes(_info.fractionMissingFile);
-}
-
-bool BaseReconciliationModel::fillPrunedNodesPostOrder(
-    corax_rnode_t *node, std::vector<corax_rnode_t *> &nodes,
-    std::unordered_set<corax_rnode_t *> *nodesToAdd) {
-  bool addMyself = true;
-  if (nodesToAdd) {
-    addMyself = (nodesToAdd->find(node) != nodesToAdd->end());
-  }
-  if (getSpeciesLeft(node)) {
-    assert(getSpeciesRight(node));
-    addMyself |=
-        fillPrunedNodesPostOrder(getSpeciesLeft(node), nodes, nodesToAdd);
-    addMyself |=
-        fillPrunedNodesPostOrder(getSpeciesRight(node), nodes, nodesToAdd);
-  }
-  if (addMyself) {
-    nodes.push_back(node);
-  }
-  return addMyself;
-}
-
-void BaseReconciliationModel::initSpeciesTree() {
-  _allSpeciesNodes.clear();
-  fillNodesPostOrder(_speciesTree.getRoot(), _allSpeciesNodes);
-  assert(getAllSpeciesNodeNumber());
-  _speciesLeft =
-      std::vector<corax_rnode_t *>(getAllSpeciesNodeNumber(), nullptr);
-  _speciesRight =
-      std::vector<corax_rnode_t *>(getAllSpeciesNodeNumber(), nullptr);
-  _speciesParent =
-      std::vector<corax_rnode_t *>(getAllSpeciesNodeNumber(), nullptr);
-  _speciesNameToId.clear();
-  onSpeciesTreeChange(nullptr);
-  for (auto node : getAllSpeciesNodes()) {
-    if (!node->left) {
-      _speciesNameToId[node->label] = node->node_index;
-    }
-  }
 }
 
 void BaseReconciliationModel::onSpeciesTreeChange(
@@ -68,14 +18,12 @@ void BaseReconciliationModel::onSpeciesTreeChange(
     _allSpeciesNodesInvalid = true;
   } else {
     assert(nodesToInvalidate->size());
-    for (auto node : *nodesToInvalidate) {
-      while (node) {
-        _invalidatedSpeciesNodes.insert(node);
-        node = node->parent;
+    for (auto speciesNode : *nodesToInvalidate) {
+      while (speciesNode) {
+        _invalidatedSpeciesNodes.insert(speciesNode);
+        speciesNode = speciesNode->parent;
       }
     }
-    _invalidatedSpeciesNodes.insert(nodesToInvalidate->begin(),
-                                    nodesToInvalidate->end());
   }
   _allSpeciesNodes.clear();
   fillNodesPostOrder(_speciesTree.getRoot(), _allSpeciesNodes);
@@ -91,7 +39,7 @@ void BaseReconciliationModel::onSpeciesTreeChange(
     for (auto speciesNode : getAllSpeciesNodes()) {
       auto e = speciesNode->node_index;
       if (!speciesNode->left) {
-        pruned[e] = (_speciesCoverage[e] ? speciesNode : nullptr);
+        pruned[e] = (_speciesCoverage[e] > 0) ? speciesNode : nullptr;
       } else {
         auto left = _speciesLeft[e];
         auto right = _speciesRight[e];
@@ -111,14 +59,89 @@ void BaseReconciliationModel::onSpeciesTreeChange(
         }
       }
     }
-    _prunedSpeciesNodes.clear();
-    fillPrunedNodesPostOrder(getPrunedRoot(), _prunedSpeciesNodes);
-  } else {
-    _prunedSpeciesNodes.clear();
-    fillNodesPostOrder(_speciesTree.getRoot(), _prunedSpeciesNodes);
   }
+  _prunedSpeciesNodes.clear();
+  fillPrunedNodesPostOrder(getPrunedRoot(), _prunedSpeciesNodes);
   assert(getAllSpeciesNodeNumber());
   assert(getPrunedSpeciesNodeNumber());
+}
+
+void BaseReconciliationModel::initSpeciesTree() {
+  // fill the list of the species nodes
+  _allSpeciesNodes.clear();
+  fillNodesPostOrder(_speciesTree.getRoot(), _allSpeciesNodes);
+  assert(getAllSpeciesNodeNumber());
+  // build the species tree structure representation
+  _speciesLeft =
+      std::vector<corax_rnode_t *>(getAllSpeciesNodeNumber(), nullptr);
+  _speciesRight =
+      std::vector<corax_rnode_t *>(getAllSpeciesNodeNumber(), nullptr);
+  _speciesParent =
+      std::vector<corax_rnode_t *>(getAllSpeciesNodeNumber(), nullptr);
+  onSpeciesTreeChange(nullptr);
+  // fill _speciesNameToId
+  _speciesNameToId.clear();
+  for (auto speciesNode : getAllSpeciesNodes()) {
+    if (!speciesNode->left) {
+      _speciesNameToId[speciesNode->label] = speciesNode->node_index;
+    }
+  }
+}
+
+void BaseReconciliationModel::fillNodesPostOrder(
+    corax_rnode_t *node, std::vector<corax_rnode_t *> &nodes) {
+  if (node->left) {
+    assert(node->right);
+    fillNodesPostOrder(node->left, nodes);
+    fillNodesPostOrder(node->right, nodes);
+  }
+  nodes.push_back(node);
+}
+
+void BaseReconciliationModel::fillPrunedNodesPostOrder(
+    corax_rnode_t *node, std::vector<corax_rnode_t *> &nodes) {
+  if (getSpeciesLeft(node)) {
+    assert(getSpeciesRight(node));
+    fillPrunedNodesPostOrder(getSpeciesLeft(node), nodes);
+    fillPrunedNodesPostOrder(getSpeciesRight(node), nodes);
+  }
+  nodes.push_back(node);
+}
+
+void BaseReconciliationModel::setFractionMissingGenes(
+    const std::string &fractionMissingFile) {
+  if (!fractionMissingFile.size()) {
+    _fm = std::vector<double>(_speciesTree.getLeafNumber(), 0.0);
+    return;
+  }
+  _fm = std::vector<double>(_speciesTree.getLeafNumber(), -1.0);
+  std::ifstream is(fractionMissingFile);
+  std::string species;
+  double fm;
+  while (is >> species >> fm) {
+    if (_speciesNameToId.find(species) == _speciesNameToId.end()) {
+      Logger::error << "Error: species " << species
+                    << " from the fraction missing file " << fractionMissingFile
+                    << " is not in the species tree" << std::endl;
+      assert(false);
+    }
+    _fm[_speciesNameToId[species]] = fm;
+  }
+  for (unsigned int i = 0; i < _speciesTree.getLeafNumber(); ++i) {
+    if (_fm[i] == -1.0) {
+      Logger::error << "Error: the fraction missing file "
+                    << fractionMissingFile << " does not cover species "
+                    << _speciesTree.getNode(i)->label << std::endl;
+      assert(false);
+    }
+  }
+}
+
+size_t BaseReconciliationModel::getSpeciesTreeHash() const {
+  if (!_prunedRoot) {
+    return 0;
+  }
+  return getTreeHashRec(_prunedRoot, 0);
 }
 
 size_t BaseReconciliationModel::getTreeHashRec(const corax_rnode_t *node,
@@ -138,44 +161,4 @@ size_t BaseReconciliationModel::getTreeHashRec(const corax_rnode_t *node,
   auto res = hash_fn(m * i + M);
   res = hash_fn(res * i + node->node_index);
   return res;
-}
-
-size_t BaseReconciliationModel::getSpeciesTreeHash() const {
-  if (!_prunedRoot) {
-    return 0;
-  }
-  return getTreeHashRec(_prunedRoot, 0);
-}
-
-void BaseReconciliationModel::beforeComputeLogLikelihood() {
-  // currently, we are not really using the fact that
-  // some species nodes should not be re-evaluated
-  _allSpeciesNodesInvalid = false;
-  _invalidatedSpeciesNodes.clear();
-  recomputeSpeciesProbabilities();
-}
-
-void BaseReconciliationModel::setFractionMissingGenes(
-    const std::string &fractionMissingFile) {
-  if (!fractionMissingFile.size()) {
-    _fm = std::vector<double>(getPrunedSpeciesNodeNumber(), 0.0);
-    return;
-  }
-  _fm = std::vector<double>(getPrunedSpeciesNodeNumber(), -1.0);
-  std::ifstream is(fractionMissingFile);
-  std::string species;
-  double fm;
-  while (is >> species >> fm) {
-    if (_speciesNameToId.find(species) != _speciesNameToId.end()) {
-      _fm[_speciesNameToId[species]] = fm;
-    }
-  }
-  for (unsigned int i = 0; i < _speciesNameToId.size(); ++i) {
-    if (_fm[i] == -1.0) {
-      std::cerr << "Error, the fraction of missing file " << fractionMissingFile
-                << " does not cover the species "
-                << _speciesTree.getNode(i)->label << std::endl;
-      assert(false);
-    }
-  }
 }

--- a/src/likelihoods/reconciliation_models/BaseReconciliationModel.hpp
+++ b/src/likelihoods/reconciliation_models/BaseReconciliationModel.hpp
@@ -1,88 +1,31 @@
 #pragma once
 
+#include <cmath>
+#include <memory>
+#include <unordered_set>
+
 #include <IO/GeneSpeciesMapping.hpp>
 #include <IO/Logger.hpp>
-#include <cmath>
-#include <likelihoods/LibpllEvaluation.hpp>
 #include <maths/Random.hpp>
 #include <maths/ScaledValue.hpp>
-#include <memory>
 #include <trees/PLLRootedTree.hpp>
-#include <unordered_set>
 #include <util/RecModelInfo.hpp>
 #include <util/Scenario.hpp>
 #include <util/enums.hpp>
 #include <util/types.hpp>
 
-#define IS_PROBA(x) (x == x) //(REAL(0.0) <= REAL(x) && REAL(x)  <= REAL(1.0)))
+#define IS_PROBA(x) ((REAL(0.0) <= REAL(x)) && (REAL(x) <= REAL(1.0)))
 #define ASSERT_PROBA(x) assert(IS_PROBA(x));
 
-double log(ScaledValue v);
-
 inline double solveSecondDegreePolynome(double a, double b, double c) {
-  return 2 * c / (-b + sqrt(b * b - 4 * a * c));
+  return (-b - sqrt(b * b - 4.0 * a * c)) / (2.0 * a);
 }
 
 /**
- *  Interface and common implementations for
- *  all the reconciliation likelihood computation
- *  classes
+ *  Common implementations for all reconciliation likelihood
+ *  computation classes
  */
-class ReconciliationModelInterface {
-public:
-  virtual ~ReconciliationModelInterface() {}
-
-  /*
-   * Set the per-species lineage rates
-   */
-  virtual void setRates(const RatesVector &rates) = 0;
-
-  virtual void setAlpha(double) {}
-
-  /**
-   * (incrementally) compute and return the likelihood of the gene tree
-   */
-  virtual double computeLogLikelihood() = 0;
-
-  /**
-   *  Sets the mode used to compute the incremental likelihood function
-   */
-  virtual void setPartialLikelihoodMode(PartialLikelihoodMode mode) = 0;
-
-  /**
-   * CLV invalidation for partial likelihood computation
-   */
-  virtual void invalidateAllSpeciesCLVs() = 0;
-  /**
-   *  Fill scenario with the maximum likelihood set of
-   *  events that would lead to the  current tree
-   *  Return true in case of success
-   **/
-  virtual bool inferMLScenario(Scenario &scenario) = 0;
-
-  /**
-   *  Sample scenarios and add them to the scenarios vector
-   *  Return true in case of success
-   */
-  virtual bool
-  sampleReconciliations(unsigned int samples,
-                        std::vector<std::shared_ptr<Scenario>> &scenarios) = 0;
-
-  /**
-   *  Should be called after each change in the species tree topology
-   */
-  virtual void onSpeciesTreeChange(
-      const std::unordered_set<corax_rnode_t *> *nodesToInvalidate) = 0;
-
-  /**
-   *  Set the path to the file containing information about
-   *  fraction of missing genes
-   */
-  virtual void
-  setFractionMissingGenes(const std::string &fractionMissingFile) = 0;
-};
-
-class BaseReconciliationModel : public ReconciliationModelInterface {
+class BaseReconciliationModel {
 public:
   BaseReconciliationModel(PLLRootedTree &speciesTree,
                           const GeneSpeciesMapping &geneSpeciesMapping,
@@ -90,118 +33,171 @@ public:
 
   virtual ~BaseReconciliationModel() {}
 
-  // overload from parent
-  virtual void invalidateAllSpeciesCLVs() { _allSpeciesNodesInvalid = true; }
-  // overload from parent
-  virtual void setPartialLikelihoodMode(PartialLikelihoodMode mode) {
-    _likelihoodMode = mode;
-  }
-  // overload from parent
-  virtual void setFractionMissingGenes(const std::string &fractionMissingFile);
-  // overload from parent
+  /**
+   *  Set the per-species branch rates
+   */
+  virtual void setRates(const RatesVector &rates) = 0;
+
+  /**
+   *  Should be called after changing speciation order on a fixed
+   *  species tree topology
+   */
+  virtual void onSpeciesDatesChange() { invalidateAllSpeciesNodes(); }
+
+  /**
+   *  Should be called after each change in the species tree topology
+   */
   virtual void onSpeciesTreeChange(
       const std::unordered_set<corax_rnode_t *> *nodesToInvalidate);
 
-  corax_rnode_t *getSpeciesLeft(corax_rnode_t *node) {
-    return _speciesLeft[node->node_index];
-  }
-
-  corax_rnode_t *getSpeciesRight(corax_rnode_t *node) {
-    return _speciesRight[node->node_index];
-  }
-
-  corax_rnode_t *getSpeciesParent(corax_rnode_t *node) {
-    return _speciesParent[node->node_index];
-  }
-
-  corax_rnode_t *getPrunedRoot() { return _prunedRoot; }
-
-protected:
-  /*
-   * Init all structures that describe the species tree, in particular
-   * the structure representing the pruned species tree in pruned mode
-   * This function should be called once at the start
+  /**
+   *  Make CLV components to be recomputed for all species nodes upon a CLV
+   * update
    */
-  virtual void initSpeciesTree();
-
-  /*
-   *  Recompute probability values depending on the species tree only
-   *  (not on the gene tree), such as the exctinction probability or
-   *  the per-species event probabilities
-   *  This function should be typically called after changing the DTL
-   *  rates or after updating the species tree.
-   */
-  virtual void recomputeSpeciesProbabilities() = 0;
+  virtual void invalidateAllSpeciesNodes() { _allSpeciesNodesInvalid = true; }
 
   /**
-   *  Callback that is always called at the start of computeLogLikelihood
+   *  (Incrementally) compute and return the reconciliation likelihood
    */
-  virtual void beforeComputeLogLikelihood();
+  virtual double computeLogLikelihood() = 0;
 
-  /*
-   * Fill nodes with the nodes of the species tree that belong to
-   * the "pruned species tree". nodesToAdd represents the species leaves
-   * are covered by this gene family. Nodes are filled in post order fashion
+  /**
+   *  Fill scenario with the maximum likelihood set of
+   *  events that would lead to the current tree.
+   *  Return true in case of success
    */
-  bool fillPrunedNodesPostOrder(
-      corax_rnode_t *node, std::vector<corax_rnode_t *> &nodes,
-      std::unordered_set<corax_rnode_t *> *nodesToAdd = nullptr);
+  virtual bool inferMLScenario(Scenario &scenario) = 0;
 
+  /**
+   *  Sample scenarios and add them to the scenarios vector.
+   *  Return true in case of success
+   */
+  virtual bool
+  sampleReconciliations(unsigned int samples,
+                        std::vector<std::shared_ptr<Scenario>> &scenarios) = 0;
+
+protected:
+  /**
+   *  Given the gene clades, fill _geneToSpecies, _speciesCoverage
+   *  and _numberOfCoveredSpecies and build the pruned species tree
+   *  representation based on the species coverage
+   */
+  virtual void mapGenesToSpecies() = 0;
+
+  /**
+   *  Accessors to the current species tree state
+   */
   PLLRootedTree &getSpeciesTree() { return _speciesTree; }
-
-  unsigned int getPrunedSpeciesNodeNumber() const {
-    return _prunedSpeciesNodes.size();
-  }
   unsigned int getAllSpeciesNodeNumber() const {
     return _allSpeciesNodes.size();
   }
-
+  unsigned int getPrunedSpeciesNodeNumber() const {
+    return _prunedSpeciesNodes.size();
+  }
   std::vector<corax_rnode_t *> &getAllSpeciesNodes() {
     return _allSpeciesNodes;
   }
   std::vector<corax_rnode_t *> &getPrunedSpeciesNodes() {
     return _prunedSpeciesNodes;
   }
+  bool prunedMode() const { return _info.pruneSpeciesTree; }
+  size_t getSpeciesTreeHash() const;
 
-  virtual size_t getSpeciesTreeHash() const;
+  /**
+   *  Accessors to the internal species tree representation
+   */
+  corax_rnode_t *getSpeciesLeft(corax_rnode_t *node) {
+    return _speciesLeft[node->node_index];
+  }
+  corax_rnode_t *getSpeciesRight(corax_rnode_t *node) {
+    return _speciesRight[node->node_index];
+  }
+  corax_rnode_t *getSpeciesParent(corax_rnode_t *node) {
+    return _speciesParent[node->node_index];
+  }
+  corax_rnode_t *getPrunedRoot() { return _prunedRoot; }
+
+  /**
+   *  Callback to be always called at the start of recomputing CLVs
+   */
+  void beforeComputeCLVs() {
+    if (_allSpeciesNodesInvalid || _invalidatedSpeciesNodes.size()) {
+      recomputeSpeciesProbabilities();
+    }
+  }
+
+private:
+  /**
+   *  Init all structures describing the species tree, in particular the
+   *  structure representing the pruned species tree in the pruned mode.
+   *  This function should be called once at the start
+   */
+  void initSpeciesTree();
+
+  /**
+   *  Fill the nodes vector with all the children of the given node based
+   *  on the pointers of the node.
+   *  Nodes are filled in the postorder fashion
+   */
+  void fillNodesPostOrder(corax_rnode_t *node,
+                          std::vector<corax_rnode_t *> &nodes);
+
+  /**
+   *  Fill the nodes vector with all the children of the given node based
+   *  on the model's species tree representation. Use to fill
+   * _prunedSpeciesNodes. Nodes are filled in the postorder fashion
+   */
+  void fillPrunedNodesPostOrder(corax_rnode_t *node,
+                                std::vector<corax_rnode_t *> &nodes);
+
+  /**
+   *  Set the path to a file containing information about the
+   *  proportions of missing genes for each extant species
+   */
+  void setFractionMissingGenes(const std::string &fractionMissingFile);
+
+  /**
+   *  Recompute probability values depending on the species tree only
+   *  (not on the gene tree), such as the exctinction probability or
+   *  the per-species event probabilities.
+   *  This function should be typically called after changing the DTL
+   *  rates or after updating the species tree
+   */
+  virtual void recomputeSpeciesProbabilities() = 0;
+
+  size_t getTreeHashRec(const corax_rnode_t *node, size_t i) const;
 
 protected:
-  // description of the model
+  // description of the recmodel
   RecModelInfo _info;
   // reference to the species tree
   PLLRootedTree &_speciesTree;
-  // list of all species tree nodes used for the likelihood computation
+  // list of all species nodes in postorder used for the likelihood computation
   std::vector<corax_rnode_t *> _allSpeciesNodes;
   std::vector<corax_rnode_t *> _prunedSpeciesNodes;
-  // map gene leaves to species leaves. The mapping is not computed by this
-  // class
-  std::vector<unsigned int> _geneToSpecies;
-  // defines at which level (species/genes/none) we do imcremental
-  // recomputations
-  PartialLikelihoodMode _likelihoodMode;
-  // fraction of missing genes, indexed by gene ids
-  std::vector<double> _fm;
-  // number of genes that cover each species leaf
-  std::vector<unsigned int> _speciesCoverage;
-  // number of species leaf that are covered by at least one gene
-  unsigned int _numberOfCoveredSpecies;
-  std::map<std::string, std::string> _geneNameToSpeciesName;
-  // species name (leaf label) to species node index
+  // map species leaf names to species leaf indices. Species leaf indices run
+  // from 0 to (_speciesTree.getLeafNumber() - 1)
   std::map<std::string, unsigned int> _speciesNameToId;
-  // if true, we have to recompute the whole likelihood from scratch
-  // (no imcremental recomputation)
+  // map gene leaf names to species leaf names
+  std::map<std::string, std::string> _geneNameToSpeciesName;
+  // map gene leaf indices to species leaf indices. Not computed by this class
+  std::map<unsigned int, unsigned int> _geneToSpecies;
+  // number of gene copies covering each species leaf. Not computed by this
+  // class
+  std::vector<unsigned int> _speciesCoverage;
+  // number of species leaves covered by this gene family. Not computed by this
+  // class
+  unsigned int _numberOfCoveredSpecies;
+  // fraction of missing genes, indexed by species leaf indices
+  std::vector<double> _fm;
+  // if true, updating a CLV will recompute its values for all species nodes
   bool _allSpeciesNodesInvalid;
-  // species internal nodes that need to be recomputed
+  // species nodes for which values of a CLV will be recomputed on its update
   std::unordered_set<corax_rnode_t *> _invalidatedSpeciesNodes;
-  // Internal representation of the current species tree. Always use these
+  // internal representation of the current species tree. Always use these
   // pointers to be compliant with the pruned species tree mode
   std::vector<corax_rnode_t *> _speciesLeft;
   std::vector<corax_rnode_t *> _speciesRight;
   std::vector<corax_rnode_t *> _speciesParent;
   corax_rnode_t *_prunedRoot;
-
-  bool prunedMode() const { return _info.pruneSpeciesTree; }
-
-private:
-  size_t getTreeHashRec(const corax_rnode_t *node, size_t i) const;
 };

--- a/src/likelihoods/reconciliation_models/GTBaseReconciliationModel.hpp
+++ b/src/likelihoods/reconciliation_models/GTBaseReconciliationModel.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "BaseReconciliationModel.hpp"
+#include <trees/PLLUnrootedTree.hpp>
 
 class GTBaseReconciliationInterface : public BaseReconciliationModel {
 public:
@@ -502,7 +503,7 @@ double GTBaseReconciliationModel<REAL>::getSumLikelihood() {
   }
   bool applyLog = !isParsimony();
   if (applyLog) {
-    return log(total) - log(this->getLikelihoodFactor());
+    return getLog(total) - getLog(this->getLikelihoodFactor());
   } else {
     return double(total);
   }

--- a/src/maths/Random.cpp
+++ b/src/maths/Random.cpp
@@ -1,11 +1,14 @@
 #include "Random.hpp"
 
+#include <cmath>
+
 std::mt19937_64 Random::_rng;
-std::uniform_int_distribution<int> Random::_unii(0);
-std::uniform_real_distribution<double> Random::_uniproba;
+std::uniform_int_distribution<int> Random::_uniint(0);
+std::uniform_real_distribution<double> Random::_uniproba(0.0, 1.0);
 
 void Random::setSeed(unsigned int seed) { _rng.seed(seed); }
-int Random::getInt() { return _unii(_rng); }
+
+int Random::getInt() { return _uniint(_rng); }
 
 int Random::getInt(unsigned int min, unsigned int max) {
   std::uniform_int_distribution<int> distr(min, max);
@@ -14,4 +17,12 @@ int Random::getInt(unsigned int min, unsigned int max) {
 
 bool Random::getBool() { return getInt() % 2; }
 
-double Random::getProba() { return _uniproba(_rng); }
+double Random::getProba() {
+  // sometimes produces 1.0, though should not; see the link:
+  // https://en.cppreference.com/w/cpp/numeric/random/uniform_real_distribution
+  double proba = _uniproba(_rng);
+  // convert 1.0 to the closest smaller double
+  if (proba == 1.0)
+    proba = std::nextafter(1.0, 0.0);
+  return proba;
+}

--- a/src/maths/Random.hpp
+++ b/src/maths/Random.hpp
@@ -1,20 +1,22 @@
 #pragma once
+
 #include <random>
 
 class Random {
 public:
   Random() = delete;
   static void setSeed(unsigned int seed);
+  // return a non-negative random int
   static int getInt();
-  /**
-   *  Return a uniform random value between min and max (included)
-   */
+  // return a uniform random int from the [min,max] interval
   static int getInt(unsigned int min, unsigned int max);
-  static double getProba();
+  // return a random bool
   static bool getBool();
+  // return a uniform random double from the [0,1) interval
+  static double getProba();
 
 private:
   static std::mt19937_64 _rng;
-  static std::uniform_int_distribution<int> _unii;
+  static std::uniform_int_distribution<int> _uniint;
   static std::uniform_real_distribution<double> _uniproba;
 };

--- a/src/maths/ScaledValue.hpp
+++ b/src/maths/ScaledValue.hpp
@@ -19,6 +19,14 @@ const int NULL_SCALER = INT_MAX / 2 - 1;
  *  When the value is null, the scaler is set to NULL_SCALER
  */
 class ScaledValue {
+private:
+  /**
+   *  General constructor
+   *  @param v value
+   *  @param s scaler
+   */
+  ScaledValue(double v, int s) : value(v), scaler(s) {}
+
 public:
   /**
    *  Null value constructor
@@ -29,14 +37,9 @@ public:
    *  Conversion constructor
    *  @param v value
    */
-  explicit ScaledValue(double v) : value(v), scaler(0) {}
-
-  /**
-   *  General constructor
-   *  @param v value
-   *  @param s scaler
-   */
-  explicit ScaledValue(double v, int s) : value(v), scaler(s) {}
+  explicit ScaledValue(double v) : value(v), scaler(0) {
+    assert(value >= 0.0); // negative values not allowed
+  }
 
   /**
    *  Conversion to a double
@@ -64,7 +67,7 @@ public:
   /**
    *  ScaledValue sum operator
    */
-  ScaledValue operator+(const ScaledValue &v) const {
+  inline ScaledValue operator+(const ScaledValue &v) const {
     if (v.scaler == scaler) {
       return ScaledValue(v.value + value, scaler);
     } else if (v.scaler < scaler) {
@@ -77,7 +80,7 @@ public:
   /**
    *  ScaledValue sum operator
    */
-  ScaledValue &operator+=(const ScaledValue &v) {
+  inline ScaledValue &operator+=(const ScaledValue &v) {
     if (v.scaler == scaler) {
       value += v.value;
     } else if (v.scaler < scaler) {
@@ -90,7 +93,7 @@ public:
   /**
    *  ScaledValue minus operator
    */
-  ScaledValue operator-(const ScaledValue &v) const {
+  inline ScaledValue operator-(const ScaledValue &v) const {
     if (v.scaler == scaler) {
       if (value - v.value < 0.0) {
         if (fabs(value - v.value) < 0.0000000001) {
@@ -105,7 +108,7 @@ public:
       return res;
     } else if (v.scaler < scaler) {
       std::cerr << *this << " - " << v << std::endl;
-      assert(false); // we do not allow negative values for now
+      assert(false); // negative values not allowed
       return v;
     } else {
       return *this;
@@ -115,7 +118,7 @@ public:
   /**
    *  ScaledValue multiplication operator
    */
-  ScaledValue operator*(const ScaledValue &v) const {
+  inline ScaledValue operator*(const ScaledValue &v) const {
     auto res = ScaledValue(v.value * value, v.scaler + scaler);
     return res;
   }
@@ -123,7 +126,7 @@ public:
   /**
    *  ScaledValue multiplication operator
    */
-  ScaledValue &operator*=(const ScaledValue &v) {
+  inline ScaledValue &operator*=(const ScaledValue &v) {
     value *= v.value;
     scaler += v.scaler;
     return *this;
@@ -132,7 +135,7 @@ public:
   /**
    *  double multiplication operator
    */
-  ScaledValue operator*(double v) const {
+  inline ScaledValue operator*(double v) const {
     auto res = ScaledValue(v * value, scaler);
     return res;
   }
@@ -140,7 +143,7 @@ public:
   /**
    *  double multiplication operator
    */
-  ScaledValue &operator*=(double v) {
+  inline ScaledValue &operator*=(double v) {
     value *= v;
     return *this;
   }
@@ -148,7 +151,7 @@ public:
   /**
    *  double division operator
    */
-  ScaledValue operator/(double v) const {
+  inline ScaledValue operator/(double v) const {
     auto res = ScaledValue(value / v, scaler);
     return res;
   }
@@ -156,7 +159,7 @@ public:
   /**
    *  double division operator
    */
-  ScaledValue &operator/=(double v) {
+  inline ScaledValue &operator/=(double v) {
     value /= v;
     return *this;
   }
@@ -164,12 +167,12 @@ public:
   /**
    *  @return true if the value is 0
    */
-  bool isNull() const { return value == 0.0; }
+  inline bool isNull() const { return value == 0.0; }
 
   /**
    *  Comparison with ScaledValue operators
    */
-  bool operator<(const ScaledValue &v) const {
+  inline bool operator<(const ScaledValue &v) const {
     if (isNull()) {
       return !v.isNull();
     }
@@ -179,18 +182,18 @@ public:
     return value < v.value;
   }
 
-  bool operator>(const ScaledValue &v) const { return !((*this) <= v); }
+  inline bool operator>(const ScaledValue &v) const { return !(*this <= v); }
 
-  bool operator==(const ScaledValue &v) const {
+  inline bool operator==(const ScaledValue &v) const {
     if (isNull()) {
       return v.isNull();
     }
     return (scaler == v.scaler) && (value == v.value);
   }
 
-  bool operator!=(const ScaledValue &v) const { return !(*this == v); }
+  inline bool operator!=(const ScaledValue &v) const { return !(*this == v); }
 
-  bool operator<=(const ScaledValue &v) const {
+  inline bool operator<=(const ScaledValue &v) const {
     if (isNull()) {
       return true;
     }
@@ -200,7 +203,7 @@ public:
     return value <= v.value;
   }
 
-  bool operator>=(const ScaledValue &v) const { return !(*this < v); }
+  inline bool operator>=(const ScaledValue &v) const { return !(*this < v); }
 
   /**
    *  std::ofstream operator
@@ -236,6 +239,8 @@ template <class REAL> void scale(REAL &) {}
 
 /**
  *  scale function for the ScaledValue type
+ *  Should be applied every time when converting from a double
+ *  or after a series of multiplication and/or division operations
  */
 template <> inline void scale<ScaledValue>(ScaledValue &v) { v.scale(); }
 

--- a/src/support/ICCalculator.cpp
+++ b/src/support/ICCalculator.cpp
@@ -18,7 +18,7 @@ ICCalculator::ICCalculator(const std::string &referenceTreePath,
                            bool paralogy)
     : _rootedReferenceTree(referenceTreePath),
       _referenceTree(_rootedReferenceTree),
-      _referenceRoot(_referenceTree.getVirtualRoot(_rootedReferenceTree)),
+      _referenceRoot(_referenceTree.getRoot(_rootedReferenceTree)),
       _perCoreGeneTrees(families), _taxaNumber(0), _paralogy(paralogy),
       _eqpicRadius(eqpicRadius) {}
 

--- a/src/trees/DatedTree.cpp
+++ b/src/trees/DatedTree.cpp
@@ -1,6 +1,8 @@
 #include "DatedTree.hpp"
-#include <IO/Logger.hpp>
+
 #include <iostream>
+
+#include <IO/Logger.hpp>
 #include <maths/Random.hpp>
 
 DatedTree::DatedTree(PLLRootedTree *rootedTree, bool fromBL)
@@ -39,7 +41,6 @@ void DatedTree::rescaleBranchLengths() {
   assert(isConsistent());
   std::vector<double> heights(_rootedTree.getNodeNumber(), 0.0);
   double height = 0.0;
-
   for (auto node : _orderedSpeciations) {
     auto e = node->node_index;
     if (!node->parent) {
@@ -138,15 +139,18 @@ size_t DatedTree::getOrderingHash(size_t startingHash) const {
   return hash;
 }
 
-bool DatedTree::canTransferUnderRelDated(unsigned int nodeIndexFrom,
-                                         unsigned int nodeIndexTo) const {
-  // father of from is before to
-  auto from = _rootedTree.getNode(nodeIndexFrom);
-  if (!from->parent) {
+bool DatedTree::canTransferUnderRelDated(unsigned int e, unsigned int d) const {
+  // the destination species (d) should be younger than
+  // the parent of the source species (e)
+  if (d == e) {
+    return false;
+  }
+  auto srcSpeciesNode = _rootedTree.getNode(e);
+  if (!srcSpeciesNode->parent) {
     return true;
   }
-  auto parentFromIndex = from->parent->node_index;
-  return _ranks[parentFromIndex] <= _ranks[nodeIndexTo];
+  auto p = srcSpeciesNode->parent->node_index;
+  return _ranks[d] > _ranks[p];
 }
 
 void DatedTree::randomize() {

--- a/src/trees/DatedTree.hpp
+++ b/src/trees/DatedTree.hpp
@@ -1,7 +1,8 @@
 #pragma once
 
-#include <trees/PLLRootedTree.hpp>
 #include <vector>
+
+#include "PLLRootedTree.hpp"
 
 class DatedTree {
 public:
@@ -39,14 +40,12 @@ public:
   }
   void restore(const Backup &backup);
 
-  bool canTransferUnderRelDated(unsigned int nodeIndexFrom,
-                                unsigned int nodeIndexTo) const;
+  bool canTransferUnderRelDated(unsigned int e, unsigned int d) const;
 
   void randomize();
 
   /**
-   *  hash value that characterizes the current order of the speciation events
-   *
+   *  Hash value that characterizes the current order of the speciation events
    */
   size_t getOrderingHash(size_t startingHash = 42) const;
 
@@ -54,7 +53,6 @@ private:
   void updateRanksFromSpeciationOrders();
 
   PLLRootedTree &_rootedTree;
-
   // internal nodes, from the root to the most recent speciation
   std::vector<corax_rnode_s *> _orderedSpeciations;
   // parents have always a lower rank than their children

--- a/src/trees/PLLRootedTree.cpp
+++ b/src/trees/PLLRootedTree.cpp
@@ -502,6 +502,14 @@ corax_rnode_t *PLLRootedTree::getLCA(unsigned int nodeIndex1,
   return _lcaCache->lcas[nodeIndex1][nodeIndex2];
 }
 
+bool PLLRootedTree::isAncestorOf(unsigned int nodeIndex1,
+                                 unsigned int nodeIndex2) {
+  if (!_lcaCache) {
+    buildLCACache();
+  }
+  return _lcaCache->ancestors[nodeIndex2][nodeIndex1];
+}
+
 bool PLLRootedTree::areParents(corax_rnode_t *n1, corax_rnode_t *n2) {
   if (!_lcaCache) {
     buildLCACache();

--- a/src/trees/PLLRootedTree.hpp
+++ b/src/trees/PLLRootedTree.hpp
@@ -175,6 +175,12 @@ public:
   corax_rnode_t *getLCA(unsigned int nodeIndex1, unsigned int nodeIndex2);
 
   /**
+   * Return true if n1 is an ancestor of n2
+   * First call is O(n^2), and all next calls O(1)
+   */
+  bool isAncestorOf(unsigned int nodeIndex1, unsigned int nodeIndex2);
+
+  /**
    * Return true if either one of n1 or n2 is parent of another
    * First call is O(n^2), and all next calls O(1)
    */

--- a/src/trees/PLLRootedTree.hpp
+++ b/src/trees/PLLRootedTree.hpp
@@ -75,6 +75,13 @@ public:
   PLLRootedTree(PLLRootedTree &&) = delete;
   PLLRootedTree &operator=(PLLRootedTree &&) = delete;
 
+  /**
+   *  Tree comparison
+   */
+  bool operator==(const PLLRootedTree &other) const {
+    return areIsomorphic(*this, other);
+  }
+
   /*
    * Tree dimension
    */
@@ -90,15 +97,6 @@ public:
   corax_rnode_t *getNode(unsigned int node_index) const;
   corax_rnode_t *getParent(unsigned int node_index) const;
   corax_rnode_t *getNeighbor(unsigned int node_index) const;
-
-  /**
-   *  Tree comparison
-   */
-  static bool areIsomorphic(const PLLRootedTree &t1, const PLLRootedTree &t2);
-
-  bool operator==(const PLLRootedTree &other) const {
-    return areIsomorphic(*this, other);
-  }
 
   /**
    * labels
@@ -239,4 +237,6 @@ private:
 
   static corax_rtree_t *
   buildRandomTree(const std::unordered_set<std::string> &leafLabels);
+
+  static bool areIsomorphic(const PLLRootedTree &t1, const PLLRootedTree &t2);
 };

--- a/src/trees/PLLUnrootedTree.hpp
+++ b/src/trees/PLLUnrootedTree.hpp
@@ -89,6 +89,9 @@ public:
   PLLUnrootedTree(PLLUnrootedTree &&) = delete;
   PLLUnrootedTree &operator=(PLLUnrootedTree &&) = delete;
 
+  /**
+   *  Tree comparison
+   */
   bool operator==(const PLLUnrootedTree &other) const {
     return areIsomorphic(*this, other);
   }
@@ -230,9 +233,6 @@ public:
    */
   static std::unordered_set<unsigned int> getClade(corax_unode_t *node);
 
-  static bool areIsomorphic(const PLLUnrootedTree &t1,
-                            const PLLUnrootedTree &t2);
-
   bool isBinary() const;
 
   void ensureUniqueLabels();
@@ -246,7 +246,7 @@ public:
    *  Return the leaf node that has the label label,
    *  or null pointer if such leaf does not exist
    */
-  corax_unode_t *findLeaf(const std::string &labe);
+  corax_unode_t *findLeaf(const std::string &label);
 
   static corax_unode_t *getLeft(corax_unode_t *node) {
     return node->next->back;
@@ -257,4 +257,7 @@ public:
 
 private:
   std::unique_ptr<corax_utree_t, void (*)(corax_utree_t *)> _tree;
+
+  static bool areIsomorphic(const PLLUnrootedTree &t1,
+                            const PLLUnrootedTree &t2);
 };

--- a/src/trees/PLLUnrootedTree.hpp
+++ b/src/trees/PLLUnrootedTree.hpp
@@ -166,21 +166,21 @@ public:
   CArrayRange<corax_unode_t *> getNodes() const;
 
   /**
-   *  Create a vector of all nodes (including all three pll
-   *  internal elements per internal node), such that a node
-   *  always comes after its (virtual) children.
-   *  - getPostOrderNodes returns all direct nodes (and skip the leaves
-   *  if innerOnly is set)
-   *  - getPostOrderNodesFrom returns all the nodes under node (including node
-   * itself)
-   *  - getPostOrderNodesRooted virtually roots the tree at virtualRoot
-   *  and returns all nodes that are directed from virtualRoot to the tips
-   *  virtualRoot and virtualRoot->back are also included
+   *  Create a vector of directed nodes (one of the three pll internal
+   *  elements per internal node), such that a node always comes after
+   *  its (virtual) children:
+   *  - getPostOrderNodes returns all directed nodes (and skip the
+   *  the leaves if innerOnly is set)
+   *  - getPostOrderNodesFrom returns all the nodes that are directed
+   *  from node to the tips (including node itself)
+   *  - getPostOrderNodesRooted returns all the nodes that are directed
+   *  from root to the tips and from root->back to the tips (root and
+   *  root->back are also included)
    */
   std::vector<corax_unode_t *> getPostOrderNodes(bool innerOnly = false) const;
   std::vector<corax_unode_t *> getPostOrderNodesFrom(corax_unode_t *node) const;
   std::vector<corax_unode_t *>
-  getPostOrderNodesRooted(corax_unode_t *virtualRoot) const;
+  getPostOrderNodesRooted(corax_unode_t *root) const;
   std::vector<corax_unode_t *> getReverseDepthNodes() const;
 
   /**
@@ -218,12 +218,12 @@ public:
   static void orientTowardEachOther(corax_unode_t **pu, corax_unode_t **pv,
                                     std::vector<corax_unode_t *> &branchesPath);
 
-  /*
-   *  Return the virtual root in the unrooted tree corresponding to
-   *  the root in the input rooted tree. Both trees should have the
-   *  same (unrooted) topology and leaf set.
+  /**
+   *  Return the node in the unrooted tree corresponding to the root
+   *  in the input rooted tree. Both trees should have the same
+   *  (unrooted) topology and leaf set
    */
-  corax_unode_t *getVirtualRoot(PLLRootedTree &referenceTree);
+  corax_unode_t *getRoot(PLLRootedTree &referenceTree, bool useRootBLs = false);
 
   // TODO: DOCUMENT
   std::vector<double> getMADRelativeDeviations();

--- a/src/util/Scenario.cpp
+++ b/src/util/Scenario.cpp
@@ -206,14 +206,14 @@ void Scenario::savePerSpeciesEventsCounts(const std::string &filename,
       eventCount[0]++;
       eventCount[4] = 1;
       eventCount[6]++;
-      if (is_speciation_event(event.previous_event_type))
+      if (is_speciation_event(event.previousType))
         eventCount[7]++;
       break;
     case ReconciliationEventType::EVENT_SL:
       eventCount[0]++;
       eventCount[4] = 1;
       eventCount[6]++;
-      if (is_speciation_event(event.previous_event_type))
+      if (is_speciation_event(event.previousType))
         eventCount[7]++;
       // count the loss
       speciesToEventCount[event.pllLostSpeciesNode->label][2]++;
@@ -782,7 +782,7 @@ static void nextLink(corax_unode_t *n1, corax_unode_t *n2, corax_unode_t *n3) {
   n3->next = n1;
 }
 
-corax_unode_t *Scenario::generateVirtualGeneRoot() {
+corax_unode_t *Scenario::generateGeneRoot() {
   auto node1 = createNode(0);
   _geneNodeBuffer.push_back(node1);
   return node1;

--- a/src/util/Scenario.hpp
+++ b/src/util/Scenario.hpp
@@ -56,17 +56,19 @@ public:
    */
   struct Event {
     Event()
-        : type(ReconciliationEventType::EVENT_S),
-          previous_event_type(ReconciliationEventType::EVENT_S),
+        : type(ReconciliationEventType::EVENT_Invalid),
+          previousType(ReconciliationEventType::EVENT_Invalid),
           geneNode(INVALID_NODE_ID), speciesNode(INVALID_NODE_ID),
-          destSpeciesNode(INVALID_NODE_ID), leftGeneIndex(INVALID_NODE_ID),
-          rightGeneIndex(INVALID_NODE_ID), pllTransferedGeneNode(nullptr),
-          pllDestSpeciesNode(nullptr), pllLostSpeciesNode(nullptr) {}
+          destSpeciesNode(INVALID_NODE_ID), lostSpeciesNode(INVALID_NODE_ID),
+          leftGeneIndex(INVALID_NODE_ID), rightGeneIndex(INVALID_NODE_ID),
+          pllTransferedGeneNode(nullptr), pllDestSpeciesNode(nullptr),
+          pllLostSpeciesNode(nullptr) {}
     ReconciliationEventType type;
-    ReconciliationEventType previous_event_type;
+    ReconciliationEventType previousType;
     unsigned int geneNode;
     unsigned int speciesNode;
-    unsigned int destSpeciesNode; // for transfers only
+    unsigned int destSpeciesNode; // for T and TL events only
+    unsigned int lostSpeciesNode; // for SL events only
 
     // left and gene indices:
     // - for speciation: left gene goes to left species
@@ -95,7 +97,7 @@ public:
    * Default constructor
    */
   Scenario()
-      : _last_event_type(ReconciliationEventType::EVENT_S),
+      : _lastEventType(ReconciliationEventType::EVENT_S),
         _eventsCount(
             static_cast<unsigned int>(ReconciliationEventType::EVENT_Invalid),
             0),
@@ -187,7 +189,7 @@ public:
   void resetBlackList();
 
   std::vector<corax_unode_t *> &getGeneNodeBuffer() { return _geneNodeBuffer; }
-  corax_unode_t *generateVirtualGeneRoot();
+  corax_unode_t *generateGeneRoot();
   void generateGeneChildren(corax_unode_t *geneNode,
                             corax_unode_t *&leftGeneNode,
                             corax_unode_t *&rightGeneNode);
@@ -201,15 +203,13 @@ public:
   corax_rnode_t *getOriginationSpecies() const;
   static const unsigned int EVENT_TYPE_NUMBER;
 
-  void setLastEventType(ReconciliationEventType type) {
-    _last_event_type = type;
-  }
-  ReconciliationEventType getLastEventType() const { return _last_event_type; }
+  void setLastEventType(ReconciliationEventType type) { _lastEventType = type; }
+  ReconciliationEventType getLastEventType() const { return _lastEventType; }
 
 private:
   static const char *eventNames[];
+  ReconciliationEventType _lastEventType;
   std::vector<Event> _events;
-  ReconciliationEventType _last_event_type;
   std::vector<unsigned int> _eventsCount;
   std::vector<std::vector<Event>> _geneIdToEvents;
   corax_unode_t *_geneRoot;


### PR DESCRIPTION
**This pull request is a dependency for the BenoitMorel/AleRax#20 PR**

Some of the changes:

- Fix the RELDATED transfer constraint (see DatedTree.cpp). Now the destination species (`d`) should be strictly younger than the parent of the source species (`e`) and these two species should be different, thus `(_rank[d] > _rank[parent(e)]) && (d != e)`. The original non-strict inequality (`_rank[d] >= _rank[parent(e)]`) made less sense and, in fact, allowed for the transfer `e -> parent(e)`.
- Refactor the ReconciliationWriter code. Comparable functions now have more similar structure. Fixed the problem with twice-too long branches at gene tree root which occured in the `.nhx` and `.alerec` outputs. Fixed indentation inaccuracies in the `.xml` output. Removed all DL event cases, because DL events are virtual and cannot even occur in a Scenario (we do not sample them during backtracing).
- Fix the problem with SL event representation in the `.xml` output when using the `--prune-species-tree` option. Now the `Scenario::Event` object has the `lostSpeciesNode` member storing the index of a species node in which the loss occurred in a SL event. The `lostSpeciesNode` is filled during backtracing and ReconciliationWriter uses this information to properly place the loss event in the species tree. GeneRax does not fill the new `lostSpeciesNode`, it should once be fixed in a separate PR.
- Refactor the ScaledValue code. The `==` operator now uses the default (flexible) precision just like all other operators. The `log(ScaledValue)` function is now defined in ScaledValue.hpp.
- Make sure that the `Random::getProba` function never returns 1.0. This is not too important, however, as using the function to get random values still needs an extra precaution to be taken (see the main PR to AleRax for the discussion).
- Fix the quadratic equation formula in the `solveSecondDegreePolynome` function (see BaseReconciliatinModel.hpp). The right formula, however, due to using doubles, leads to strictly zero extinction probabilities (`_uE`) when the duplication parameter is low. This leads to an error whenever we need to explain a loss event. The new version of AleRax doesn't use this formula, yet GeneRax still does, which will once be fixed in a separate PR.

As mentioned above, the PR makes GeneRaxCore incompatible with GeneRax. The incompatibilities lie in the reconciliation models used by GeneRax, hence they should be a subject of yet another fix. This does not cause any compilation or runtime errors when using AleRax (and not a problem for GeneRax either, as GeneRax still uses Benoit's library version).