### PR TITLE
Refactor speciation dating

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -5,3 +5,4 @@ Language: Cpp
 Standard: Cpp11
 
 UseTab: Never
+AllowShortLoopsOnASingleLine: true

--- a/src/IO/Families.hpp
+++ b/src/IO/Families.hpp
@@ -6,7 +6,7 @@
 struct FamilyInfo {
   std::string name;
   std::string startingGeneTree;
-  std::string ccp;
+  std::string ccpFile;
   std::string alignmentFile;
   std::string mappingFile;
   std::string libpllModel;
@@ -17,7 +17,7 @@ struct FamilyInfo {
   void reset() {
     name = "";
     startingGeneTree = "__random__";
-    ccp = "";
+    ccpFile = "";
     alignmentFile = "";
     mappingFile = "";
     libpllModel = "GTR";

--- a/src/likelihoods/ReconciliationEvaluation.cpp
+++ b/src/likelihoods/ReconciliationEvaluation.cpp
@@ -150,6 +150,11 @@ corax_unode_t *ReconciliationEvaluation::inferMLRoot() {
   return res;
 }
 
+void ReconciliationEvaluation::onSpeciesDatesChange() {
+  assert(_evaluators);
+  _evaluators->onSpeciesDatesChange();
+}
+
 void ReconciliationEvaluation::onSpeciesTreeChange(
     const std::unordered_set<corax_rnode_t *> *nodesToInvalidate) {
   assert(_evaluators);

--- a/src/likelihoods/ReconciliationEvaluation.hpp
+++ b/src/likelihoods/ReconciliationEvaluation.hpp
@@ -62,9 +62,10 @@ public:
     return Enums::accountsForTransfers(_recModelInfo.model);
   }
 
-  /*
-   *  Call this everytime that the species tree changes
+  /**
+   *  Update node information after modifying the species tree
    */
+  void onSpeciesDatesChange();
   void onSpeciesTreeChange(
       const std::unordered_set<corax_rnode_t *> *nodesToInvalidate);
 

--- a/src/likelihoods/reconciliation_models/BaseReconciliationModel.cpp
+++ b/src/likelihoods/reconciliation_models/BaseReconciliationModel.cpp
@@ -12,6 +12,7 @@ BaseReconciliationModel::BaseReconciliationModel(
 
 void BaseReconciliationModel::onSpeciesTreeChange(
     const std::unordered_set<corax_rnode_t *> *nodesToInvalidate) {
+  // invalidated species nodes
   if (!nodesToInvalidate) {
     _allSpeciesNodesInvalid = true;
   } else {
@@ -23,6 +24,7 @@ void BaseReconciliationModel::onSpeciesTreeChange(
       }
     }
   }
+  // full species tree representation
   _allSpeciesNodes.clear();
   fillNodesPostOrder(_speciesTree.getRoot(), _allSpeciesNodes);
   for (auto speciesNode : getAllSpeciesNodes()) {
@@ -32,20 +34,22 @@ void BaseReconciliationModel::onSpeciesTreeChange(
     _speciesParent[e] = speciesNode->parent;
   }
   _prunedRoot = _speciesTree.getRoot();
+  // pruned species tree representation
   if (_speciesCoverage.size()) {
     std::fill(_speciesToPrunedNode.begin(), _speciesToPrunedNode.end(),
               nullptr);
     for (auto speciesNode : getAllSpeciesNodes()) {
       auto e = speciesNode->node_index;
+      if (prunedMode()) {
+        _speciesLeft[e] = _speciesRight[e] = _speciesParent[e] = nullptr;
+      }
       if (!speciesNode->left) { // leaf node
         if (_speciesCoverage[e] > 0) {
           _speciesToPrunedNode[e] = speciesNode;
         }
       } else { // internal node
-        auto left = _speciesLeft[e];
-        auto right = _speciesRight[e];
-        auto prunedLeft = _speciesToPrunedNode[left->node_index];
-        auto prunedRight = _speciesToPrunedNode[right->node_index];
+        auto prunedLeft = _speciesToPrunedNode[speciesNode->left->node_index];
+        auto prunedRight = _speciesToPrunedNode[speciesNode->right->node_index];
         if (prunedLeft && prunedRight) { // the node belongs to pruned nodes
           _speciesToPrunedNode[e] = speciesNode;
           if (prunedMode()) {

--- a/src/optimizers/SpeciesTreeOptimizer.cpp
+++ b/src/optimizers/SpeciesTreeOptimizer.cpp
@@ -10,6 +10,7 @@
 #include <search/SpeciesTransferSearch.hpp>
 #include <support/ICCalculator.hpp>
 #include <util/Paths.hpp>
+#include <util/utils.hpp>
 
 static std::unique_ptr<SpeciesTree>
 makeSpeciesTree(const std::string &speciesTreeFile,

--- a/src/optimizers/SpeciesTreeOptimizer.hpp
+++ b/src/optimizers/SpeciesTreeOptimizer.hpp
@@ -95,6 +95,7 @@ public:
   SpeciesTreeOptimizer &operator=(SpeciesTreeOptimizer &&) = delete;
   virtual ~SpeciesTreeOptimizer();
 
+  virtual void onSpeciesDatesChange();
   virtual void onSpeciesTreeChange(
       const std::unordered_set<corax_rnode_t *> *nodesToInvalidate);
 

--- a/src/parallelization/ParallelContext.cpp
+++ b/src/parallelization/ParallelContext.cpp
@@ -1,8 +1,11 @@
-#include "parallelization/ParallelContext.hpp"
-#include <IO/Logger.hpp>
+#include "ParallelContext.hpp"
+
 #include <algorithm>
 #include <cassert>
 #include <cmath>
+#include <numeric>
+
+#include <IO/Logger.hpp>
 #include <maths/Random.hpp>
 
 std::ofstream ParallelContext::sink("/dev/null");
@@ -232,6 +235,7 @@ void ParallelContext::allGatherInt(int localValue,
   assert(false);
 #endif
 }
+
 void ParallelContext::allGatherUInt(unsigned int localValue,
                                     std::vector<unsigned int> &allValues) {
   if (!_mpiEnabled) {
@@ -254,7 +258,6 @@ void ParallelContext::concatenateIntVectors(const std::vector<int> &localVector,
     globalVector = localVector;
     return;
   }
-
 #ifdef WITH_MPI
   globalVector.resize(getSize() * localVector.size(), 0);
   MPI_Allgather(&localVector[0], static_cast<int>(localVector.size()), MPI_INT,
@@ -272,7 +275,6 @@ void ParallelContext::concatenateUIntVectors(
     globalVector = localVector;
     return;
   }
-
 #ifdef WITH_MPI
   globalVector.resize(getSize() * localVector.size(), 0);
   MPI_Allgather(&localVector[0], static_cast<int>(localVector.size()),
@@ -283,7 +285,7 @@ void ParallelContext::concatenateUIntVectors(
 #endif
 }
 
-void ParallelContext::concatenateHetherogeneousDoubleVectors(
+void ParallelContext::concatenateHeterogeneousDoubleVectors(
     const std::vector<double> &localVector, std::vector<double> &globalVector) {
   if (!_mpiEnabled) {
     globalVector = localVector;
@@ -311,8 +313,8 @@ void ParallelContext::concatenateHetherogeneousDoubleVectors(
 #endif
 }
 
-void ParallelContext::concatenateHetherogeneousUIntVectors(
-    std::vector<unsigned int> localVector,
+void ParallelContext::concatenateHeterogeneousUIntVectors(
+    const std::vector<unsigned int> &localVector,
     std::vector<unsigned int> &globalVector) {
   if (!_mpiEnabled) {
     globalVector = localVector;
@@ -459,7 +461,7 @@ bool ParallelContext::isDoubleEqual(double value) {
   std::vector<double> rands(getSize());
   allGatherDouble(value, rands);
   for (auto v : rands) {
-    if (fabs(v - rands[0]) > 0.00000001) {
+    if (std::fabs(v - rands[0]) > 0.00000001) {
       std::cout << "KO " << v << " " << rands[0] << std::endl;
       std::cerr << "KO " << v << " " << rands[0] << std::endl;
       return false;

--- a/src/parallelization/ParallelContext.hpp
+++ b/src/parallelization/ParallelContext.hpp
@@ -1,8 +1,11 @@
 #pragma once
 
+#include <exception>
 #include <fstream>
 #include <stack>
+#include <string>
 #include <vector>
+
 #ifdef WITH_MPI
 #include <mpi.h>
 #else
@@ -10,22 +13,22 @@ typedef int MPI_Comm;
 #endif
 
 /**
- * Singleton class that handles parallelization routines
+ *  Singleton class that handles parallelization routines
  */
 class ParallelContext {
 public:
   ParallelContext() = delete;
 
   /**
-   *  Initialize the parallel context. Must always be called at the start of the
-   * programm
-   *  @param commPtr a pointer to the MPI communicator used by this programm
+   *  Initialize the parallel context. Must always be called at the start of
+   *  the program
+   *  @param commPtr a pointer to the MPI communicator used by this program
    */
   static void init(void *commPtr);
 
   /**
-   *  Terminates the parallel context. Must always be called at the end of the
-   * programm
+   *  Terminate the parallel context. Must always be called at the end of
+   *  the program
    */
   static void finalize();
 
@@ -40,7 +43,7 @@ public:
   static unsigned int getSize();
 
   /**
-   * Gather the values of each rank into a global std::vector
+   *  Gather the values of each rank into a global std::vector
    *  @param localValue input value for this rank
    *  @param allValues output values for all rank (indexed with the rank index)
    */
@@ -56,7 +59,7 @@ public:
   static bool isDoubleEqual(double value);
 
   /**
-   * Concatenates vectors of same sizes
+   *  Concatenate vectors of same sizes
    */
   static void concatenateIntVectors(const std::vector<int> &localVector,
                                     std::vector<int> &globalVector);
@@ -65,14 +68,14 @@ public:
                          std::vector<unsigned int> &globalVector);
 
   /**
-   * Concatenates vectors of different sizes
+   *  Concatenate vectors of different sizes
    */
+  static void concatenateHeterogeneousUIntVectors(
+      const std::vector<unsigned int> &localVector,
+      std::vector<unsigned int> &globalVector);
   static void
-  concatenateHetherogeneousUIntVectors(std::vector<unsigned int> localVector,
-                                       std::vector<unsigned int> &globalVector);
-  static void
-  concatenateHetherogeneousDoubleVectors(const std::vector<double> &localVector,
-                                         std::vector<double> &globalVector);
+  concatenateHeterogeneousDoubleVectors(const std::vector<double> &localVector,
+                                        std::vector<double> &globalVector);
 
   static void sumDouble(double &value);
   static void sumUInt(unsigned int &value);
@@ -83,7 +86,7 @@ public:
   static void parallelAnd(bool &value);
 
   /**
-   *  broadcast a value from a given rank
+   *  Broadcast a value from a given rank
    *  @param fromRank rank from which we want the value
    *  @param value input value for this rank, output value for the other ranks
    */
@@ -94,7 +97,7 @@ public:
   /**
    *  Get the highest value from all ranks
    *  @param value as input, the value for the current rank. As output,
-   *    the highest value among the ranks
+   *               the highest value among the ranks
    *  @param bestRank the rank that has the highest value
    */
   static unsigned int getMax(double &value, unsigned int &bestRank);
@@ -129,14 +132,13 @@ private:
   static std::stack<MPI_Comm> _commStack;
   static std::stack<bool> _ownsMPIContextStack;
   static bool _mpiEnabled;
+
   class ParallelException : public std::exception {
   public:
     ParallelException(int errorCode) {
       msg_ = "Program failed with error " + std::to_string(errorCode);
     }
-
     virtual ~ParallelException() {}
-
     virtual const char *what() const noexcept { return msg_.c_str(); }
 
   private:

--- a/src/parallelization/PerCoreGeneTrees.cpp
+++ b/src/parallelization/PerCoreGeneTrees.cpp
@@ -1,28 +1,20 @@
 #include "PerCoreGeneTrees.hpp"
+
+#include <cassert>
+#include <sstream>
+
 #include <IO/FileSystem.hpp>
 #include <IO/LibpllParsers.hpp>
 #include <IO/Logger.hpp>
-#include <algorithm>
 #include <ccp/ConditionalClades.hpp>
-#include <iostream>
-#include <numeric>
 #include <parallelization/ParallelContext.hpp>
-#include <sstream>
 #include <trees/PLLRootedTree.hpp>
-
-template <typename T>
-std::vector<size_t> sort_indexes_descending(const std::vector<T> &v) {
-  std::vector<size_t> idx(v.size());
-  iota(idx.begin(), idx.end(), 0);
-  sort(idx.begin(), idx.end(),
-       [&v](size_t i1, size_t i2) { return v[i1] > v[i2]; });
-  return idx;
-}
+#include <util/utils.hpp>
 
 static std::vector<size_t>
 getMyIndices(const std::vector<unsigned int> &treeSizes) {
   std::vector<size_t> sortedIndices =
-      sort_indexes_descending<unsigned int>(treeSizes);
+      sort_indices_descending<unsigned int>(treeSizes);
   std::vector<size_t> myIndices;
   std::vector<unsigned int> perRankLoad(ParallelContext::getSize(), 0);
   unsigned int averageLoad = 0;
@@ -62,7 +54,7 @@ std::vector<unsigned int> getCCPSizes(const Families &families) {
   for (auto i = ParallelContext::getBegin(treesNumber);
        i < ParallelContext::getEnd(treesNumber); i++) {
     ConditionalClades cc;
-    cc.unserialize(families[i].ccp);
+    cc.unserialize(families[i].ccpFile);
     localTreeSizes[i - ParallelContext::getBegin(treesNumber)] =
         cc.getCladesNumber();
   }

--- a/src/search/Moves.cpp
+++ b/src/search/Moves.cpp
@@ -1,5 +1,7 @@
+#include "Moves.hpp"
+
 #include <IO/Logger.hpp>
-#include <search/Moves.hpp>
+#include <parallelization/ParallelContext.hpp>
 #include <trees/JointTree.hpp>
 
 // constants taken from RAXML
@@ -150,10 +152,10 @@ void SPRMove::synchronizeOptimizedBL(JointTree &tree) {
   }
   std::vector<unsigned int> globalIndices;
   std::vector<double> globalLengths;
-  ParallelContext::concatenateHetherogeneousUIntVectors(branchIndices,
-                                                        globalIndices);
-  ParallelContext::concatenateHetherogeneousDoubleVectors(branchLengths,
-                                                          globalLengths);
+  ParallelContext::concatenateHeterogeneousUIntVectors(branchIndices,
+                                                       globalIndices);
+  ParallelContext::concatenateHeterogeneousDoubleVectors(branchLengths,
+                                                         globalLengths);
   _optimizedBranches.clear();
   _optimizedBackBranches.clear();
   assert(globalIndices.size() == globalLengths.size());

--- a/src/search/SPRSearch.cpp
+++ b/src/search/SPRSearch.cpp
@@ -1,12 +1,10 @@
+#include "SPRSearch.hpp"
+
+#include "Moves.hpp"
+#include "SearchUtils.hpp"
 #include <IO/Logger.hpp>
-#include <array>
 #include <parallelization/ParallelContext.hpp>
-#include <search/Moves.hpp>
-#include <search/SPRSearch.hpp>
-#include <search/SearchUtils.hpp>
 #include <trees/JointTree.hpp>
-#include <unordered_map>
-#include <unordered_set>
 
 struct SPRMoveDesc {
   SPRMoveDesc(unsigned int prune, unsigned int regraft,
@@ -249,8 +247,8 @@ static void synchronizeMoves(JointTree &jointTree,
   }
   std::vector<unsigned int> prune;
   std::vector<unsigned int> regraft;
-  ParallelContext::concatenateHetherogeneousUIntVectors(localPrune, prune);
-  ParallelContext::concatenateHetherogeneousUIntVectors(localRegraft, regraft);
+  ParallelContext::concatenateHeterogeneousUIntVectors(localPrune, prune);
+  ParallelContext::concatenateHeterogeneousUIntVectors(localRegraft, regraft);
   auto temp = moves;
   moves.clear();
   assert(prune.size() == regraft.size());

--- a/src/search/SpeciesRootSearch.cpp
+++ b/src/search/SpeciesRootSearch.cpp
@@ -34,8 +34,8 @@ static void rootSearchAux(SpeciesTree &speciesTree,
     ll = evaluator.computeLikelihood(&perFamLL);
     if (treePerFamLLVec) {
       PerFamLL globalPerFamLL;
-      ParallelContext::concatenateHetherogeneousDoubleVectors(perFamLL,
-                                                              globalPerFamLL);
+      ParallelContext::concatenateHeterogeneousDoubleVectors(perFamLL,
+                                                             globalPerFamLL);
       auto newick = speciesTree.toString();
       treePerFamLLVec->push_back({newick, globalPerFamLL});
     }
@@ -77,8 +77,8 @@ double SpeciesRootSearch::rootSearch(
   if (treePerFamLLVec) {
     treePerFamLLVec->clear();
     PerFamLL globalPerFamLL;
-    ParallelContext::concatenateHetherogeneousDoubleVectors(perFamLL,
-                                                            globalPerFamLL);
+    ParallelContext::concatenateHeterogeneousDoubleVectors(perFamLL,
+                                                           globalPerFamLL);
     auto newick = speciesTree.toString();
     treePerFamLLVec->push_back({newick, globalPerFamLL});
   }

--- a/src/search/SpeciesRootSearch.cpp
+++ b/src/search/SpeciesRootSearch.cpp
@@ -1,8 +1,8 @@
 #include "SpeciesRootSearch.hpp"
 
 #include "DatedSpeciesTreeSearch.hpp"
-#include <numeric>
-#include <trees/PLLRootedTree.hpp>
+#include <IO/Logger.hpp>
+#include <parallelization/ParallelContext.hpp>
 #include <trees/SpeciesTree.hpp>
 
 static void rootSearchAux(SpeciesTree &speciesTree,
@@ -10,9 +10,8 @@ static void rootSearchAux(SpeciesTree &speciesTree,
                           SpeciesSearchState &searchState,
                           std::vector<unsigned int> &movesHistory,
                           std::vector<unsigned int> &bestMovesHistory,
-                          DatedTree::Backup &bestDatedBackup, double &bestLL,
-                          double bestLLStack, unsigned int &visits,
-                          unsigned int maxDepth,
+                          DatedBackup &bestDatedBackup, double &bestLL,
+                          double bestLLStack, unsigned int maxDepth,
                           RootLikelihoods *rootLikelihoods,
                           TreePerFamLLVec *treePerFamLLVec) {
   if (movesHistory.size() > maxDepth) {
@@ -21,54 +20,48 @@ static void rootSearchAux(SpeciesTree &speciesTree,
   std::vector<unsigned int> moves;
   moves.push_back(movesHistory.back() % 2);
   moves.push_back(2 + (movesHistory.back() % 2));
-  auto backup = speciesTree.getDatedTree().getBackup();
   for (auto direction : moves) {
     if (!SpeciesTreeOperator::canChangeRoot(speciesTree, direction)) {
       continue;
     }
     movesHistory.push_back(direction);
     evaluator.pushRollback();
+    auto backup = speciesTree.getDatedTree().getBackup();
     SpeciesTreeOperator::changeRoot(speciesTree, direction);
     double ll = DatedSpeciesTreeSearch::optimizeDates(
-        speciesTree, evaluator, searchState, searchState.farFromPlausible);
+        speciesTree, evaluator, searchState, !searchState.farFromPlausible);
     PerFamLL perFamLL;
     ll = evaluator.computeLikelihood(&perFamLL);
     if (treePerFamLLVec) {
       PerFamLL globalPerFamLL;
       ParallelContext::concatenateHetherogeneousDoubleVectors(perFamLL,
                                                               globalPerFamLL);
-      auto newick = speciesTree.getTree().getNewickString();
+      auto newick = speciesTree.toString();
       treePerFamLLVec->push_back({newick, globalPerFamLL});
     }
-    auto root = speciesTree.getRoot();
     if (rootLikelihoods) {
+      auto root = speciesTree.getRoot();
       rootLikelihoods->saveRootLikelihood(root, ll);
       rootLikelihoods->savePerFamilyLikelihoods(root, perFamLL);
     }
-    visits++;
-    unsigned int additionalDepth = 0;
+    auto newMaxDepth = maxDepth;
     if (ll > bestLLStack) {
-      additionalDepth = 2;
       bestLLStack = ll;
+      newMaxDepth = movesHistory.size() + 2;
     }
     if (ll > bestLL) {
       bestLL = ll;
       bestMovesHistory = movesHistory;
       bestDatedBackup = speciesTree.getDatedTree().getBackup();
       Logger::timed << "\tbetter root: LL=" << ll << std::endl;
-      searchState.betterTreeCallback(ll, perFamLL);
-    }
-    auto newMaxDepth = maxDepth;
-    if (additionalDepth) {
-      newMaxDepth = movesHistory.size() + additionalDepth;
     }
     rootSearchAux(speciesTree, evaluator, searchState, movesHistory,
                   bestMovesHistory, bestDatedBackup, bestLL, bestLLStack,
-                  visits, newMaxDepth, rootLikelihoods, treePerFamLLVec);
+                  newMaxDepth, rootLikelihoods, treePerFamLLVec);
     SpeciesTreeOperator::revertChangeRoot(speciesTree, direction);
+    SpeciesTreeOperator::restoreDates(speciesTree, backup);
     evaluator.popAndApplyRollback();
     movesHistory.pop_back();
-    speciesTree.getDatedTree().restore(backup);
   }
 }
 
@@ -79,45 +72,38 @@ double SpeciesRootSearch::rootSearch(
     RootLikelihoods *rootLikelihoods, TreePerFamLLVec *treePerFamLLVec) {
   Logger::timed << "[Species search] Root search with depth=" << maxDepth
                 << std::endl;
-  std::vector<unsigned int> movesHistory;
-  std::vector<unsigned int> bestMovesHistory;
   PerFamLL perFamLL;
-  double bestLL = evaluator.computeLikelihood(&perFamLL);
+  double initialLL = evaluator.computeLikelihood(&perFamLL);
   if (treePerFamLLVec) {
+    treePerFamLLVec->clear();
     PerFamLL globalPerFamLL;
     ParallelContext::concatenateHetherogeneousDoubleVectors(perFamLL,
                                                             globalPerFamLL);
-    treePerFamLLVec->clear();
-    auto newick = speciesTree.getTree().getNewickString();
+    auto newick = speciesTree.toString();
     treePerFamLLVec->push_back({newick, globalPerFamLL});
   }
-  auto root = speciesTree.getRoot();
   if (rootLikelihoods) {
-    rootLikelihoods->saveRootLikelihood(root, bestLL);
+    auto root = speciesTree.getRoot();
+    rootLikelihoods->saveRootLikelihood(root, initialLL);
     rootLikelihoods->savePerFamilyLikelihoods(root, perFamLL);
   }
-  unsigned int visits = 1;
-  movesHistory.push_back(1);
-  double temp1 = bestLL;
-  double temp2 = bestLL;
+  double bestLL = initialLL;
+  std::vector<unsigned int> movesHistory;
+  std::vector<unsigned int> bestMovesHistory;
   auto bestDatedBackup = speciesTree.getDatedTree().getBackup();
+  movesHistory.push_back(1);
   rootSearchAux(speciesTree, evaluator, searchState, movesHistory,
-                bestMovesHistory, bestDatedBackup, bestLL, temp1, visits,
-                maxDepth, rootLikelihoods, treePerFamLLVec);
+                bestMovesHistory, bestDatedBackup, bestLL, initialLL, maxDepth,
+                rootLikelihoods, treePerFamLLVec);
   movesHistory[0] = 0;
   rootSearchAux(speciesTree, evaluator, searchState, movesHistory,
-                bestMovesHistory, bestDatedBackup, bestLL, temp2, visits,
-                maxDepth, rootLikelihoods, treePerFamLLVec);
+                bestMovesHistory, bestDatedBackup, bestLL, initialLL, maxDepth,
+                rootLikelihoods, treePerFamLLVec);
   for (unsigned int i = 1; i < bestMovesHistory.size(); ++i) {
     SpeciesTreeOperator::changeRoot(speciesTree, bestMovesHistory[i]);
   }
-  speciesTree.getDatedTree().restore(bestDatedBackup);
-  if (rootLikelihoods) {
-    auto newick = speciesTree.getTree().getNewickString();
-    PLLRootedTree tree(newick, false);
-    rootLikelihoods->fillTree(tree);
-  }
-  Logger::timed << "[Species search] After root search: LL=" << bestLL << " "
+  SpeciesTreeOperator::restoreDates(speciesTree, bestDatedBackup);
+  Logger::timed << "[Species search] After root search: LL=" << bestLL
                 << std::endl;
   return bestLL;
 }

--- a/src/search/SpeciesTransferSearch.cpp
+++ b/src/search/SpeciesTransferSearch.cpp
@@ -1,10 +1,13 @@
 #include "SpeciesTransferSearch.hpp"
 
-#include "SpeciesSearchCommon.hpp"
-#include <IO/FileSystem.hpp>
 #include <algorithm>
-#include <trees/PLLRootedTree.hpp>
+#include <cassert>
+
+#include "SpeciesSearchCommon.hpp"
+#include <IO/Logger.hpp>
+#include <parallelization/ParallelContext.hpp>
 #include <trees/SpeciesTree.hpp>
+#include <util/Scenario.hpp>
 
 void PerCorePotentialTransfers::addScenario(const Scenario &scenario) {
   auto famCopies = scenario.getPerSpeciesCopies();
@@ -51,12 +54,12 @@ void SpeciesTransferSearch::getSortedTransferList(
   }
   unsigned int transfers = 0;
   ParallelContext::barrier();
-  std::unordered_map<std::string, unsigned int> labelsToIds;
-  speciesTree.getLabelsToId(labelsToIds);
+  StringToUint labelToId;
+  speciesTree.getLabelToId(labelToId);
   for (unsigned int from = 0; from < frequencies.count.size(); ++from) {
     for (unsigned int to = 0; to < frequencies.count.size(); ++to) {
-      auto regraft = labelsToIds[frequencies.idToLabel[from]];
-      auto prune = labelsToIds[frequencies.idToLabel[to]];
+      auto regraft = labelToId[frequencies.idToLabel[from]];
+      auto prune = labelToId[frequencies.idToLabel[to]];
       auto count = frequencies.count[from][to];
       transfers += count;
       if (count < minTransfers) {

--- a/src/trees/Clade.cpp
+++ b/src/trees/Clade.cpp
@@ -49,7 +49,7 @@ Clade Clade::getComplement(Clade &allTaxa) {
 
 Clade Clade::getMaximumClade(PLLRootedTree &tree) {
   Clade clade;
-  for (auto &p : tree.getLabelToIntMap()) {
+  for (auto &p : tree.getLeafLabelToId()) {
     clade._ids.insert(p.second);
   }
   clade._recomputeHash();

--- a/src/trees/Clade.cpp
+++ b/src/trees/Clade.cpp
@@ -1,9 +1,9 @@
 #include "Clade.hpp"
+
 #include <IO/GeneSpeciesMapping.hpp>
-#include <algorithm>
-#include <functional>
 #include <trees/PLLRootedTree.hpp>
 #include <trees/PLLUnrootedTree.hpp>
+#include <util/utils.hpp>
 
 static unsigned int hashTwoValues(unsigned int a, unsigned int b) {
   /*
@@ -85,7 +85,7 @@ CladeSet Clade::buildCladeSet(PLLRootedTree &tree) {
 
 CladeSet Clade::buildCladeSet(PLLUnrootedTree &tree,
                               const GeneSpeciesMapping &geneSpeciesMapping,
-                              const StringToUintMap &speciesLabelToInt) {
+                              const StringToUint &speciesLabelToInt) {
   auto postOrderNodes = tree.getPostOrderNodes();
   std::vector<Clade> clades(postOrderNodes.size());
   for (auto node : postOrderNodes) {

--- a/src/trees/Clade.hpp
+++ b/src/trees/Clade.hpp
@@ -1,14 +1,13 @@
 #pragma once
 
-#include <cstddef>
 #include <iostream>
-#include <set>
-#include <unordered_map>
-#include <util/enums.hpp>
 
-class PLLUnrootedTree;
-class PLLRootedTree;
+#include <util/types.hpp>
+
 class GeneSpeciesMapping;
+class PLLRootedTree;
+class PLLUnrootedTree;
+
 using CladeSet = std::set<size_t>;
 
 class Clade {
@@ -17,6 +16,7 @@ public:
 
   void mergeWith(const Clade &clade);
   void addId(unsigned int id);
+
   size_t getHash() const { return _hash; }
   friend std::ostream &operator<<(std::ostream &os, const Clade &c) {
     os << "[(";
@@ -35,7 +35,7 @@ public:
 
   static CladeSet buildCladeSet(PLLUnrootedTree &tree,
                                 const GeneSpeciesMapping &geneSpeciesMapping,
-                                const StringToUintMap &speciesLabelToInt);
+                                const StringToUint &speciesLabelToInt);
 
 private:
   void _recomputeHash();
@@ -43,19 +43,3 @@ private:
   std::set<unsigned int> _ids;
   size_t _hash;
 };
-
-struct Counter {
-  struct value_type {
-    template <typename T> value_type(const T &) {}
-  };
-  void push_back(const value_type &) { ++count; }
-  size_t count = 0;
-};
-
-template <typename T1, typename T2>
-size_t intersection_size(const T1 &s1, const T2 &s2) {
-  Counter c;
-  set_intersection(s1.begin(), s1.end(), s2.begin(), s2.end(),
-                   std::back_inserter(c));
-  return c.count;
-}

--- a/src/trees/DatedTree.cpp
+++ b/src/trees/DatedTree.cpp
@@ -1,136 +1,126 @@
 #include "DatedTree.hpp"
 
-#include <iostream>
+#include <cassert>
+#include <functional>
 
-#include <IO/Logger.hpp>
 #include <maths/Random.hpp>
 
-DatedTree::DatedTree(PLLRootedTree *rootedTree, bool fromBL)
-    : _rootedTree(*rootedTree) {
-  if (fromBL) {
-    _orderedSpeciations = _rootedTree.getOrderedSpeciations();
-  } else {
-    auto postOrder = rootedTree->getPostOrderNodes();
-    for (auto it = postOrder.rbegin(); it != postOrder.rend(); ++it) {
+DatedTree::DatedTree(PLLRootedTree &rootedTree, bool useBLs)
+    : _fromBL(useBLs), _rootedTree(rootedTree) {
+  // get _orderedSpeciations and _ranks either from tree topology
+  // or from branch lengths
+  _ranks.resize(_rootedTree.getNodeNumber(), 0);
+  updateSpeciationOrderAndRanks();
+  // standardize branch lengths either by default or from _ranks
+  rescaleBranchLengths();
+}
+
+void DatedTree::updateSpeciationOrderAndRanks() {
+  // update _orderedSpeciations
+  _orderedSpeciations.clear();
+  if (!_fromBL) { // order the speciations in reverse postorder
+    auto nodes = _rootedTree.getPostOrderNodes();
+    for (auto it = nodes.rbegin(); it != nodes.rend(); ++it) {
       auto node = *it;
-      if (node->left) {
-        _orderedSpeciations.push_back(node);
-      }
+      _orderedSpeciations.push_back(node);
     }
+  } else { // order the speciations according to branch lengths
+    _orderedSpeciations = _rootedTree.getOrderedSpeciations();
   }
-  updateRanksFromSpeciationOrders();
-}
-
-void DatedTree::reorderFromBranchLengths() {
-  _orderedSpeciations = _rootedTree.getOrderedSpeciations();
-  updateRanksFromSpeciationOrders();
-}
-
-void DatedTree::updateRanksFromSpeciationOrders() {
-  _ranks.resize(_rootedTree.getNodeNumber());
+  // update _ranks
   unsigned int rank = 0;
-  for (auto species : _orderedSpeciations) {
-    _ranks[species->node_index] = rank++;
-  }
-  for (auto leaf : this->_rootedTree.getLeaves()) {
-    _ranks[leaf->node_index] = rank;
+  for (auto node : _orderedSpeciations) {
+    _ranks[node->node_index] = rank++;
   }
 }
 
 void DatedTree::rescaleBranchLengths() {
-  assert(isConsistent());
-  std::vector<double> heights(_rootedTree.getNodeNumber(), 0.0);
-  double height = 0.0;
-  for (auto node : _orderedSpeciations) {
-    auto e = node->node_index;
-    if (!node->parent) {
-      node->length = 1.0;
-      continue;
+  // check _ranks
+  checkRanks();
+  // update branch lengths
+  if (!_fromBL) { // set all lengths to a standard value
+    _rootedTree.equalizeBranchLengths();
+  } else { // set lengths according to _ranks
+    double treeHeight = 0.0;
+    for (auto node : _orderedSpeciations) {
+      if (!node->parent || !node->left) { // the root or a leaf
+        node->length = 1.0;               // not included in treeHeight
+        continue;
+      }
+      auto e = node->node_index;
+      auto p = node->parent->node_index;
+      node->length = double(_ranks[e]) - double(_ranks[p]);
+      treeHeight = double(_ranks[e]);
     }
-    auto p = node->parent->node_index;
-    node->length = double(_ranks[e]) - double(_ranks[p]);
-    height = _ranks[e];
-  }
-  height += 1.0;
-  for (auto leaf : _rootedTree.getLeaves()) {
-    auto p = leaf->parent->node_index;
-    leaf->length = height - double(_ranks[p]);
+    treeHeight += 1.0; // account for the leaves
+    for (auto leaf : _rootedTree.getLeaves()) {
+      auto p = leaf->parent->node_index;
+      leaf->length = treeHeight - double(_ranks[p]);
+    }
   }
 }
 
-bool DatedTree::moveUp(unsigned int rank, bool force) {
+bool DatedTree::moveUp(unsigned int rank) {
+  assert(_fromBL);
   if (rank == 0) {
     return false;
   }
-  return moveDown(rank - 1, force);
+  // move the previous node one rank away from the root
+  return moveDown(rank - 1);
 }
 
-bool DatedTree::moveDown(unsigned int rank, bool force) {
+bool DatedTree::moveDown(unsigned int rank) {
+  assert(_fromBL);
   if (rank > _orderedSpeciations.size() - 2) {
     return false;
   }
   auto n1 = _orderedSpeciations[rank];
   auto n2 = _orderedSpeciations[rank + 1];
-  // n1 is above n2. We want to swap them
-  if (!force && n2->parent == n1) {
+  // n1 has a lower rank than n2. We want to swap them
+  if (!n1->left || !n2->left || n2->parent == n1) {
     return false;
   }
   _orderedSpeciations[rank + 1] = n1;
   _orderedSpeciations[rank] = n2;
-  assert(_ranks[n2->node_index] - _ranks[n1->node_index] == 1);
   _ranks[n1->node_index]++;
   _ranks[n2->node_index]--;
   return true;
 }
 
-void DatedTree::moveNodeToRoot(corax_rnode_t *node) {
-  auto e = node->node_index;
-  auto rank = _ranks[e];
-  while (rank != 0) {
-    auto ok = moveUp(rank, true);
-    assert(ok);
-    rank = _ranks[e];
-  }
-  assert(rank == _ranks[e]);
-}
-
-bool DatedTree::isConsistent() const {
-  // check that _orderedSpeciations and ranks are consistent
+void DatedTree::checkRanks() const {
+  // check that _ranks are consistent with _orderedSpeciations
   for (unsigned int i = 0; i < _orderedSpeciations.size() - 1; ++i) {
     auto n1 = _orderedSpeciations[i];
     auto n2 = _orderedSpeciations[i + 1];
-    if (_ranks[n1->node_index] + 1 != _ranks[n2->node_index]) {
-      return false;
-    }
+    assert(_ranks[n1->node_index] + 1 == _ranks[n2->node_index]);
   }
-  // check that the ranks are consistent with the tree structure
+  // check that _ranks are consistent with the tree topology
   for (auto node : _rootedTree.getNodes()) {
     if (node->parent) {
-      auto p = node->parent->node_index;
       auto e = node->node_index;
-      if (_ranks[p] > _ranks[e]) {
-        return false;
-      }
+      auto p = node->parent->node_index;
+      assert(_ranks[p] < _ranks[e]);
     }
   }
-  return true;
 }
 
-void DatedTree::restore(const Backup &backup) {
-  _ranks = backup.ranks;
+void DatedTree::restore(const DatedBackup &backup) {
+  _ranks = backup;
   auto speciations = _orderedSpeciations;
   for (auto node : speciations) {
     _orderedSpeciations[_ranks[node->node_index]] = node;
   }
 }
 
+// TODO: Too high hash collision rate! Fix somehow before using!
 // taken from https://stackoverflow.com/a/27952689
-size_t hash_combine(size_t lhs, size_t rhs) {
+static size_t hash_combine(size_t lhs, size_t rhs) {
   lhs ^= rhs + 0x9e3779b9 + (lhs << 6) + (lhs >> 2);
   return lhs;
 }
 
 size_t DatedTree::getOrderingHash(size_t startingHash) const {
+  assert(_fromBL);
   std::hash<size_t> hash_fn;
   size_t hash = hash_fn(startingHash);
   for (auto rank : _ranks) {
@@ -154,6 +144,7 @@ bool DatedTree::canTransferUnderRelDated(unsigned int e, unsigned int d) const {
 }
 
 void DatedTree::randomize() {
+  assert(_fromBL);
   std::vector<corax_rnode_t *> toAdd;
   toAdd.push_back(_rootedTree.getRoot());
   unsigned int currentRank = 0;

--- a/src/trees/DatedTree.hpp
+++ b/src/trees/DatedTree.hpp
@@ -1,60 +1,55 @@
 #pragma once
 
-#include <vector>
-
 #include "PLLRootedTree.hpp"
 
+/**
+ *  Wrapper around PLLRootedTree handling the order of speciations
+ */
 class DatedTree {
 public:
-  DatedTree(PLLRootedTree *rootedTree, bool fromBL = true);
+  DatedTree(PLLRootedTree &rootedTree, bool useBLs);
 
-  void reorderFromBranchLengths();
-  void rescaleBranchLengths();
+  const PLLRootedTree &getRootedTree() const { return _rootedTree; }
+  PLLRootedTree &getRootedTree() { return _rootedTree; }
 
-  PLLRootedTree &getRootedTree() const { return _rootedTree; }
-  const std::vector<corax_rnode_s *> &getOrderedSpeciations() const {
+  bool isDated() const { return _fromBL; }
+
+  const std::vector<corax_rnode_t *> &getOrderedSpeciations() const {
     return _orderedSpeciations;
-  }
-  unsigned int getRank(unsigned int nodeIndex) const {
-    return _ranks[nodeIndex];
   }
   const std::vector<unsigned int> &getOrderedSpeciesRanks() const {
     return _ranks;
   }
-
-  bool moveDown(unsigned int rank, bool force = false);
-  bool moveUp(unsigned int rank, bool force = false);
-
-  void moveNodeToRoot(corax_rnode_t *node);
-
-  bool isConsistent() const;
-
-  struct Backup {
-    std::vector<unsigned int> ranks;
-  };
-
-  Backup getBackup() {
-    Backup backup;
-    backup.ranks = _ranks;
-    return backup;
+  unsigned int getRank(corax_rnode_t *node) const {
+    return _ranks[node->node_index];
   }
-  void restore(const Backup &backup);
+  DatedBackup getBackup() const { return _ranks; }
+
+  void updateSpeciationOrderAndRanks();
+  void rescaleBranchLengths();
+
+  bool moveUp(unsigned int rank);
+  bool moveDown(unsigned int rank);
+
+  void restore(const DatedBackup &backup);
 
   bool canTransferUnderRelDated(unsigned int e, unsigned int d) const;
 
   void randomize();
 
   /**
-   *  Hash value that characterizes the current order of the speciation events
+   *  Hash value characterizing the current order of speciations
    */
   size_t getOrderingHash(size_t startingHash = 42) const;
 
 private:
-  void updateRanksFromSpeciationOrders();
+  void checkRanks() const;
 
+private:
+  const bool _fromBL;
   PLLRootedTree &_rootedTree;
-  // internal nodes, from the root to the most recent speciation
-  std::vector<corax_rnode_s *> _orderedSpeciations;
-  // parents have always a lower rank than their children
+  // all nodes, from the root to the most recent speciation followed by leaves
+  std::vector<corax_rnode_t *> _orderedSpeciations;
+  // ranks for all nodes, parents always have a lower rank than their children
   std::vector<unsigned int> _ranks;
 };

--- a/src/trees/PLLRootedTree.hpp
+++ b/src/trees/PLLRootedTree.hpp
@@ -107,9 +107,9 @@ public:
                                  std::unordered_set<std::string> &labels);
 
   /**
-   *  Get a mapping from label to integer
+   *  Get a mapping from a leaf label to the leaf node index
    */
-  StringToUintMap getLabelToIntMap();
+  StringToUint getLeafLabelToId() const;
 
   /*
    * Save the tree in newick format in filename

--- a/src/trees/SpeciesTree.cpp
+++ b/src/trees/SpeciesTree.cpp
@@ -1,36 +1,53 @@
 #include "SpeciesTree.hpp"
+
+#include <algorithm>
 #include <cassert>
-
-#include <IO/FileSystem.hpp>
 #include <functional>
-#include <likelihoods/LibpllEvaluation.hpp>
-#include <likelihoods/ReconciliationEvaluation.hpp>
+
+#include <IO/GeneSpeciesMapping.hpp>
 #include <parallelization/ParallelContext.hpp>
-#include <parallelization/PerCoreGeneTrees.hpp>
-#include <set>
 
-SpeciesTree::SpeciesTree(const std::string &newick, bool fromFile)
-    : _speciesTree(newick, fromFile), _datedTree(&_speciesTree) {}
+static std::unordered_set<std::string>
+getLabelsFromFamilies(const Families &families) {
+  std::unordered_set<std::string> leafLabels;
+  for (const auto &family : families) {
+    GeneSpeciesMapping mapping;
+    mapping.fill(family.mappingFile, family.startingGeneTree);
+    for (const auto &p : mapping.getMap()) {
+      leafLabels.insert(p.second);
+    }
+  }
+  return leafLabels;
+}
 
-SpeciesTree::SpeciesTree(const std::unordered_set<std::string> &leafLabels)
-    : _speciesTree(leafLabels), _datedTree(&_speciesTree) {}
+SpeciesTree::SpeciesTree(const std::string &str, bool isFile, bool useBLs)
+    : _speciesTree(str, isFile), _datedTree(_speciesTree, useBLs) {}
+
+SpeciesTree::SpeciesTree(const std::unordered_set<std::string> &labels)
+    : _speciesTree(labels), _datedTree(_speciesTree, false) {}
+
+SpeciesTree::SpeciesTree(const Families &families)
+    : _speciesTree(getLabelsFromFamilies(families)),
+      _datedTree(_speciesTree, false) {}
 
 std::unique_ptr<SpeciesTree> SpeciesTree::buildRandomTree() const {
   return std::make_unique<SpeciesTree>(_speciesTree.getLabels(true));
 }
 
-SpeciesTree::SpeciesTree(const Families &families)
-    : _speciesTree(getLabelsFromFamilies(families)), _datedTree(&_speciesTree) {
-}
-
-void SpeciesTree::saveToFile(const std::string &newick, bool masterRankOnly) {
+void SpeciesTree::saveToFile(const std::string &fileName,
+                             bool masterRankOnly) const {
   if (masterRankOnly && ParallelContext::getRank()) {
     return;
   }
-  _speciesTree.save(newick);
+  _speciesTree.save(fileName);
 }
 
-std::string SpeciesTree::toString() { return _speciesTree.getNewickString(); }
+void SpeciesTree::getLabelToId(StringToUint &labelToId) const {
+  labelToId.clear();
+  for (auto node : getTree().getNodes()) {
+    labelToId[std::string(node->label)] = node->node_index;
+  }
+}
 
 void SpeciesTree::addListener(Listener *listener) {
   _listeners.push_back(listener);
@@ -41,13 +58,26 @@ void SpeciesTree::removeListener(Listener *listener) {
                    _listeners.end());
 }
 
+void SpeciesTree::onSpeciesDatesChange() {
+  _datedTree.rescaleBranchLengths(); // update branch lengths
+  for (auto listener : _listeners) {
+    listener->onSpeciesDatesChange();
+  }
+}
+
 void SpeciesTree::onSpeciesTreeChange(
     const std::unordered_set<corax_rnode_t *> *nodesToInvalidate) {
+  _datedTree.rescaleBranchLengths();                   // update branch lengths
+  _speciesTree.onSpeciesTreeChange(nodesToInvalidate); // update labels and lcas
   for (auto listener : _listeners) {
     listener->onSpeciesTreeChange(nodesToInvalidate);
   }
-  _speciesTree.onSpeciesTreeChange(nodesToInvalidate);
-  _datedTree.reorderFromBranchLengths(); // make sure the dates still make sense
+}
+
+void SpeciesTreeOperator::restoreDates(SpeciesTree &speciesTree,
+                                       const DatedBackup &backup) {
+  speciesTree.getDatedTree().restore(backup);
+  speciesTree.onSpeciesDatesChange();
 }
 
 static void setRootAux(SpeciesTree &speciesTree, corax_rnode_t *root) {
@@ -64,14 +94,6 @@ bool SpeciesTreeOperator::canChangeRoot(const SpeciesTree &speciesTree,
   return newRoot->left && newRoot->right;
 }
 
-std::string sideString(bool left) {
-  if (left) {
-    return std::string("left");
-  } else {
-    return std::string("right");
-  }
-}
-
 void SpeciesTreeOperator::changeRoot(SpeciesTree &speciesTree,
                                      unsigned int direction) {
   bool left1 = direction % 2;
@@ -86,30 +108,33 @@ void SpeciesTreeOperator::changeRoot(SpeciesTree &speciesTree,
   auto D = rootRight->right;
   std::unordered_set<corax_rnode_t *> nodesToInvalidate;
   nodesToInvalidate.insert(root);
-  auto &datedTree = speciesTree.getDatedTree();
   setRootAux(speciesTree, left1 ? rootLeft : rootRight);
   if (left1 && left2) {
     PLLRootedTree::setSon(rootLeft, root, false);
     PLLRootedTree::setSon(root, B, true);
     PLLRootedTree::setSon(root, rootRight, false);
-    datedTree.moveNodeToRoot(rootLeft);
   } else if (!left1 && !left2) {
     PLLRootedTree::setSon(rootRight, root, true);
     PLLRootedTree::setSon(root, C, false);
     PLLRootedTree::setSon(root, rootLeft, true);
-    datedTree.moveNodeToRoot(rootRight);
   } else if (left1 && !left2) {
     PLLRootedTree::setSon(rootLeft, rootLeft->right, true);
     PLLRootedTree::setSon(rootLeft, root, false);
     PLLRootedTree::setSon(root, A, false);
     PLLRootedTree::setSon(root, rootRight, true);
-    datedTree.moveNodeToRoot(rootLeft);
   } else { // !left1 && left2
     PLLRootedTree::setSon(rootRight, root, true);
     PLLRootedTree::setSon(rootRight, C, false);
     PLLRootedTree::setSon(root, D, true);
     PLLRootedTree::setSon(root, rootLeft, false);
-    datedTree.moveNodeToRoot(rootRight);
+  }
+  auto newRoot = root->parent;
+  auto &datedTree = speciesTree.getDatedTree();
+  if (datedTree.isDated()) {
+    while (datedTree.moveUp(datedTree.getRank(newRoot)))
+      ; // move newRoot rank
+  } else {
+    datedTree.updateSpeciationOrderAndRanks(); // get ranks from topology
   }
   speciesTree.onSpeciesTreeChange(&nodesToInvalidate);
 }
@@ -179,6 +204,9 @@ unsigned int SpeciesTreeOperator::applySPRMove(SpeciesTree &speciesTree,
                           pruneFatherNode->left != pruneNode);
     nodesToInvalidate.insert(regraftParentNode);
   }
+  auto &datedTree = speciesTree.getDatedTree();
+  assert(!datedTree.isDated());
+  datedTree.updateSpeciationOrderAndRanks(); // get ranks from topology
   speciesTree.onSpeciesTreeChange(&nodesToInvalidate);
   return res;
 }
@@ -327,28 +355,4 @@ size_t SpeciesTree::getHash() const {
 size_t SpeciesTree::getNodeIndexHash() const {
   auto res = getTreeHashRec(getTree().getRoot(), 0, false);
   return res % 100000;
-}
-
-void SpeciesTree::getLabelsToId(
-    std::unordered_map<std::string, unsigned int> &map) const {
-  map.clear();
-  for (auto node : getTree().getNodes()) {
-    map.insert(
-        std::pair<std::string, unsigned int>(node->label, node->node_index));
-  }
-}
-
-std::unordered_set<std::string>
-SpeciesTree::getLabelsFromFamilies(const Families &families) {
-  GeneSpeciesMapping mappings;
-  for (const auto &family : families) {
-    std::string geneTreeStr;
-    // FileSystem::getFileContent(family.startingGeneTree, geneTreeStr);
-    mappings.fill(family.mappingFile, family.startingGeneTree);
-  }
-  std::unordered_set<std::string> leaves;
-  for (auto &mapping : mappings.getMap()) {
-    leaves.insert(mapping.second);
-  }
-  return leaves;
 }

--- a/src/trees/SpeciesTree.cpp
+++ b/src/trees/SpeciesTree.cpp
@@ -131,8 +131,7 @@ void SpeciesTreeOperator::changeRoot(SpeciesTree &speciesTree,
   auto newRoot = root->parent;
   auto &datedTree = speciesTree.getDatedTree();
   if (datedTree.isDated()) {
-    while (datedTree.moveUp(datedTree.getRank(newRoot)))
-      ; // move newRoot rank
+    while (datedTree.moveUp(datedTree.getRank(newRoot))); // move newRoot rank
   } else {
     datedTree.updateSpeciationOrderAndRanks(); // get ranks from topology
   }

--- a/src/util/Scenario.cpp
+++ b/src/util/Scenario.cpp
@@ -227,12 +227,14 @@ void Scenario::savePerSpeciesEventsCounts(const std::string &filename,
       break;
     case ReconciliationEventType::EVENT_T:
       eventCount[3]++;
-      speciesToEventCount[_speciesTree->nodes[event.destSpeciesNode]->label][8]++;
+      speciesToEventCount[_speciesTree->nodes[event.destSpeciesNode]->label]
+                         [8]++;
       break;
     case ReconciliationEventType::EVENT_TL:
       eventCount[2]++;
       eventCount[3]++;
-      speciesToEventCount[_speciesTree->nodes[event.destSpeciesNode]->label][8]++;
+      speciesToEventCount[_speciesTree->nodes[event.destSpeciesNode]->label]
+                         [8]++;
       break;
     case ReconciliationEventType::EVENT_L:
     case ReconciliationEventType::EVENT_Invalid:

--- a/src/util/types.hpp
+++ b/src/util/types.hpp
@@ -1,29 +1,41 @@
 #pragma once
+
 #include <array>
+#include <map>
+#include <set>
+#include <string>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
+
+typedef struct corax_unode_s corax_unode_t;
+typedef struct corax_utree_s corax_utree_t;
+typedef struct corax_rnode_s corax_rnode_t;
+typedef struct corax_rtree_s corax_rtree_t;
 
 using VectorDouble = std::vector<double>;
 using MatrixDouble = std::vector<VectorDouble>;
 using DistanceMatrix = MatrixDouble;
 using VectorUint = std::vector<unsigned int>;
 using MatrixUint = std::vector<VectorUint>;
+using VectorString = std::vector<std::string>;
 using StringToUint = std::unordered_map<std::string, unsigned int>;
 using StringToInt = std::unordered_map<std::string, int>;
 
 using SPID = unsigned int; // species ID
 using BID = unsigned int;  // branch ID
 using CID = unsigned int;  // clade ID
+using GID = unsigned int;  // gene ID
 using TaxaSet = std::unordered_set<SPID>;
 using MetaQuartet = std::array<TaxaSet, 4>;
 using UInt3 = std::array<unsigned int, 3>;
 using UInt4 = std::array<unsigned int, 4>;
 using PairUInt = std::pair<unsigned int, unsigned int>;
 using PerFamLL = std::vector<double>;
+using DatedBackup = std::vector<unsigned int>;
 using RatesVector = std::vector<std::vector<double>>;
 
 struct TransferFrequencies {
   MatrixUint count;
-  std::vector<std::string> idToLabel;
+  VectorString idToLabel;
 };

--- a/src/util/utils.hpp
+++ b/src/util/utils.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <algorithm>
+#include <iterator>
+#include <numeric>
+#include <vector>
+
+/**
+ *  Return the indices of the input vector sorted in descending order
+ */
+template <typename T>
+std::vector<size_t> sort_indices_descending(const std::vector<T> &v) {
+  std::vector<size_t> idx(v.size());
+  std::iota(idx.begin(), idx.end(), 0);
+  std::sort(idx.begin(), idx.end(),
+            [&v](size_t i1, size_t i2) { return v[i1] > v[i2]; });
+  return idx;
+}
+
+struct Counter {
+  struct value_type {
+    template <typename T> value_type(const T &) {}
+  };
+  void push_back(const value_type &) { ++count; }
+  size_t count = 0;
+};
+
+/**
+ *  Return the number of elements present in both sorted containers
+ */
+template <typename T1, typename T2>
+size_t intersection_size(const T1 &s1, const T2 &s2) {
+  Counter c;
+  std::set_intersection(s1.begin(), s1.end(), s2.begin(), s2.end(),
+                        std::back_inserter(c));
+  return c.count;
+}


### PR DESCRIPTION
**This pull request is a dependency for the BenoitMorel/AleRax#30 PR**

Some of the changes:

1. Update the clang-format file to permit single-line loops of type `while(bool_returning_func());`.
2. Fix a typo in the `ParallelContext::concatenateHeterogeneousUIntVectors` function name and make the function accept its input by reference, not by copy.
3. Move some commonly used general-purpose functions to `util/utils.hpp` and add some more commonly used types to `util/types.hpp` to make the code more modular.
4. Fixed the pruned species tree representation in `BaseReconciliationModel`. Now, when running in the pruned mode, the  `_speciesLeft`, `_speciesRight`, `_speciesParent` pointers can be non-null only for the nodes of the pruned species tree.
5. Refactor the `SpeciesRootSearch` class code without changing the search algorithm:
5.1. Fix the `searchState.farFromPlausible` interpretation. Now, `true` means that we are far from the plausible tree rooting and, hence, should apply only fast non-thorough dating, and `false` means that the rooting is almost optimal and can be improved with slower thorough dating. The default value is `true`.
5.2. Delegate the `searchState` update (the bestLL update and tree saving) to the `DatedSpeciesTreeSearch::optimizeDates` function. The function computes and compares the current tree likelihood with the `searchState.bestLL` and updates the  `searchState`, there is no need to repeat the update in the `rootSearchAux` function.
5.3. Make sure that the dating backup is applied before performing any operations with the likelihood evaluator and that the evaluator's precomputed data get invalidated upon applying the backup (see more on this below).
6. Refactor the `DatedSpeciesTreeSearch` class code without changing the search algorithm. The essence of the changes is:
6.1. The species tree is saved to file only when it has likelihood better than `searchState.bestLL`, the saving is performed by means of calling the `searchState.betterTreeCallback` function.
6.2. The `optimizeDates` function first always evaluates the likelihood of the provided initial species tree, then in the RELDATED mode, it iteratively optimizes the initial species tree datings tracking the tree likelihood. If at any point the likelihood becomes better than `searchState.bestLL`, the `searchState` gets updated. So the function can start with and proceed optimizing an initial tree that is worse than the best known tree, yet it will return the optimized tree anyway and it will save the tree if it becomes better than the best known tree. This behaviour is used in the `SpeciesRootSearch` class (see above).
6.3. The `getBestDatingsFromReconciliation` function returns scored backups without changing the dating of the input species tree and the state of the input likelihood evaluator. Since the function does not update the species tree, it does not need to use `searchState` at any point.
6.4. Everything else is just cosmetic changes.
7. Fix how node dates, branch lengths, and likelihood evaluator's precomputed data are updated by the `SpeciesTree` class:
7.1. During tree initialization, the information flow is `branch lengths -> node dates` (see the `DatedTree` class constructor). During tree search, the information flow is `node dates -> branch lengths` (see the `DatedTree::rescaleBranchLengths` function).
7.2. When node dates are changed, the branch lengths are rescaled and the precomputed evaluator's data are invalidated; this is done by the `SpeciesTree::onSpeciesDatesChange` callback function. Since restoring dates from a `DatedBackup` changes node dates, the restoring is now performed by the `SpeciesTreeOperator::restoreDates` function, which includes the callback function (merging the backup and the callback functions simplifies the code and prevents coding errors).
7.3. When the tree topology is changed, the node dates are changed directly by either the `SpeciesTreeOperator::changeRoot` or `SpeciesTreeOperator::applySPRMove` function, then the branch lengths are rescaled and the precomputed evaluator's data are invalidated by the `SpeciesTree::onSpeciesTreeChange` callback function.
8. Redefine the role of the `DatedTree` class. Now, all species tree nodes, even leaves, are given distinct ranks. In the RELDATED mode, the leaves are ranked deterministically based on their gene labels and always higher than inner nodes; in other cases, all nodes are ranked in reverse postorder. In the RELDATED mode, the rank information is transferred to the species tree branch lengths, however, ranks of the leaves do not affect branch lengths (so the tree is ultrametric). The ranks and the branch lengths are always kept up to date during dating or topology search, this guarantees that the tree is saved correctly.

Some of these changes may seem unnecessary now, yet they are designed to be useful in the future PR that will propose a time-linear algorithm for computing DTLCLV transfer sums.